### PR TITLE
fix: pypi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Extract version from tag
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            # Strip the 'v' prefix from the tag
+            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Update version in pyproject.toml
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          echo "Setting version to $VERSION"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
+          echo "Updated pyproject.toml:"
+          grep "^version" pyproject.toml
 
       - name: Install build tools
         run: python -m pip install --upgrade build


### PR DESCRIPTION
Automatic release publishing was not working.  Latest release on pypi is 0.5.1.  GHA run for 0.5.6 failed to publish because the package was built with an 0.5.1 name and then uploading fails with an HTTP 400 as the file already exists.

Update the release job to extract the version and update `pyproject.toml` before building.

---

Obviously I have not been able to test this end-to-end.  As much as anything else, please consider this PR a bug report that automatic publishing is not working.  The [GHA run for 0.5.6](https://github.com/Maxteabag/sqlit/actions/runs/20248387328/job/58134305921) fails with:

```txt
Uploading sqlit_tui-0.5.1-py3-none-any.whl
WARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/        
         File already exists ('sqlit_tui-0.5.1-py3-none-any.whl', with          
         blake2_256 hash                                                        
         '652f71f646e3927eace6b3654be0d1f23a72d3e50ae3a359433d0530d828d4e0').   
         See https://pypi.org/help/#file-name-reuse for more information.
```
