### PR TITLE
Lean on hatch-vcs for managing the package version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,28 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Extract version from tag
-        id: version
-        run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            # Strip the 'v' prefix from the tag
-            echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-
-      - name: Update version in pyproject.toml
-        run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
-          echo "Setting version to $VERSION"
-          sed -i "s/^version = .*/version = \"$VERSION\"/" pyproject.toml
-          echo "Updated pyproject.toml:"
-          grep "^version" pyproject.toml
 
       - name: Install build tools
         run: python -m pip install --upgrade build

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ sqlit-notifications/
 # Integration test artifacts
 tests/integration/python_packages/artifacts/
 
+sqlit/_version.py
+
 # Local assets (except logo for README)
 assets/*
 !assets/favorites/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "sqlit-tui"
-version = "0.5.1"
 description = "A terminal UI for SQL Server, PostgreSQL, MySQL, SQLite, Oracle, and more"
 readme = "README.md"
 license = "MIT"
@@ -33,6 +32,7 @@ dependencies = [
     "keyring>=24.0.0",
     "docker>=7.0.0",  # Docker container auto-detection (lazy loaded)
 ]
+dynamic = ["version"]
 
 [project.optional-dependencies]
 all = [
@@ -85,6 +85,12 @@ dev = [
     "mypy>=1.0",
     "pre-commit>=3.0",
 ]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "sqlit/_version.py"
 
 [tool.ruff]
 target-version = "py310"

--- a/sqlit/__init__.py
+++ b/sqlit/__init__.py
@@ -12,6 +12,11 @@ __all__ = [
     "ConnectionConfig",
 ]
 
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "0.0.0.dev"
+
 if TYPE_CHECKING:
     from .app import SSMSTUI
     from .cli import main
@@ -19,27 +24,8 @@ if TYPE_CHECKING:
     from importlib.metadata import PackageNotFoundError  # noqa: F401
 
 
-_VERSION_CACHE: str | None = None
-
-
-def _get_version() -> str:
-    global _VERSION_CACHE
-    if _VERSION_CACHE is not None:
-        return _VERSION_CACHE
-    try:
-        from importlib.metadata import PackageNotFoundError, version
-
-        _VERSION_CACHE = version("sqlit-tui")
-    except PackageNotFoundError:
-        # Package not installed (development mode without editable install)
-        _VERSION_CACHE = "0.0.0.dev"
-    return _VERSION_CACHE
-
-
 def __getattr__(name: str) -> Any:
     """Lazy import for heavy modules to keep package import side-effect free."""
-    if name == "__version__":
-        return _get_version()
     if name == "main":
         from .cli import main
 

--- a/uv.lock
+++ b/uv.lock
@@ -2959,7 +2959,6 @@ wheels = [
 
 [[package]]
 name = "sqlit-tui"
-version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
Not sure how interested you are in this, but I figure I'd might as well check.

This simplifies the mechanics of the release build a tad and means `pyproject.toml` doesn't need to be updated. It also means that `__version__` is now a lot cheaper to determine as `_version.py` will be automatically generated with the correct information at build time.

Here's an example of triggering the build with `uv build` after creating the tag `v1.2.0`:
```console
$ uv build
Building source distribution...
Building wheel from source distribution...
Successfully built dist/sqlit_tui-1.2.0.tar.gz
Successfully built dist/sqlit_tui-1.2.0-py3-none-any.whl
```
And the same with `build`:
```console
$ uv run python -m build
      Built sqlit-tui @ file:///home/keith/projects/sqlit
Uninstalled 1 package in 0.56ms
Installed 1 package in 1ms
* Creating isolated environment: virtualenv+pip...
* Installing packages in isolated environment:
  - hatch-vcs
  - hatchling
* Getting build dependencies for sdist...
* Building sdist...
* Building wheel from sdist
* Creating isolated environment: virtualenv+pip...
* Installing packages in isolated environment:
  - hatch-vcs
  - hatchling
* Getting build dependencies for wheel...
* Building wheel...
Successfully built sqlit_tui-1.2.0.tar.gz and sqlit_tui-1.2.0-py3-none-any.whl
```
There should be no behavioural changes from how things currently work.