### PR TITLE
Fix MySQL driver: migrate from mysql-connector-python to PyMySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Most of the time you can just run `sqlit` and connect. If a Python driver is mis
 | SQLite                              | *(built-in)*                 | *(built-in)*                                       | *(built-in)*                                       |
 | PostgreSQL / CockroachDB / Supabase | `psycopg2-binary`            | `pipx inject sqlit-tui psycopg2-binary`            | `python -m pip install psycopg2-binary`            |
 | SQL Server                          | `mssql-python`               | `pipx inject sqlit-tui mssql-python`               | `python -m pip install mssql-python`               |
-| MySQL                               | `mysql-connector-python`     | `pipx inject sqlit-tui mysql-connector-python`     | `python -m pip install mysql-connector-python`     |
+| MySQL                               | `PyMySQL`                    | `pipx inject sqlit-tui PyMySQL`                    | `python -m pip install PyMySQL`                    |
 | MariaDB                             | `mariadb`                    | `pipx inject sqlit-tui mariadb`                    | `python -m pip install mariadb`                    |
 | Oracle                              | `oracledb`                   | `pipx inject sqlit-tui oracledb`                   | `python -m pip install oracledb`                   |
 | DuckDB                              | `duckdb`                     | `pipx inject sqlit-tui duckdb`                     | `python -m pip install duckdb`                     |

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -16,7 +16,7 @@ pkgbase = python-sqlit-tui
 	depends = python-docker>=7.0.0
 	optdepends = python-psycopg2: PostgreSQL, CockroachDB and Supabase support
 	optdepends = python-pyodbc: SQL Server support
-	optdepends = python-mysql-connector: MySQL support
+	optdepends = python-pymysql: MySQL support
 	optdepends = python-mariadb-connector: MariaDB support
 	optdepends = python-oracledb: Oracle support
 	optdepends = python-duckdb: DuckDB support

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -17,7 +17,7 @@ depends=(
 optdepends=(
     'python-psycopg2: PostgreSQL, CockroachDB and Supabase support'
     'python-pyodbc: SQL Server support'
-    'python-mysql-connector: MySQL support'
+    'python-pymysql: MySQL support'
     'python-mariadb-connector: MariaDB support'
     'python-oracledb: Oracle support'
     'python-duckdb: DuckDB support'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ namespace_packages = true
 
 [[tool.mypy.overrides]]
 module = [
-    "mysql.connector",
+    "pymysql",
     "mariadb",
     "oracledb",
     "duckdb",

--- a/sqlit/db/adapters/mysql.py
+++ b/sqlit/db/adapters/mysql.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import importlib.util
 from typing import TYPE_CHECKING, Any
 
+from ..exceptions import MissingDriverError
 from ..schema import get_default_port
 from .base import MySQLBaseAdapter, import_driver_module
 
 if TYPE_CHECKING:
     from ...config import ConnectionConfig
+
+
+def _check_old_mysql_connector() -> bool:
+    """Check if the old mysql-connector-python package is installed."""
+    return importlib.util.find_spec("mysql.connector") is not None
 
 
 class MySQLAdapter(MySQLBaseAdapter):
@@ -56,12 +63,29 @@ class MySQLAdapter(MySQLBaseAdapter):
 
     def connect(self, config: ConnectionConfig) -> Any:
         """Connect to MySQL database."""
-        pymysql = import_driver_module(
-            "pymysql",
-            driver_name=self.name,
-            extra_name=self.install_extra,
-            package_name=self.install_package,
-        )
+        try:
+            pymysql = import_driver_module(
+                "pymysql",
+                driver_name=self.name,
+                extra_name=self.install_extra,
+                package_name=self.install_package,
+            )
+        except MissingDriverError:
+            # Check if user has the old mysql-connector-python installed
+            if _check_old_mysql_connector():
+                raise MissingDriverError(
+                    self.name,
+                    self.install_extra,
+                    self.install_package,
+                    module_name="pymysql",
+                    import_error=(
+                        "MySQL driver has changed from mysql-connector-python to PyMySQL.\n"
+                        "Please uninstall the old package and install PyMySQL:\n"
+                        "  pip uninstall mysql-connector-python\n"
+                        "  pip install PyMySQL"
+                    ),
+                ) from None
+            raise
 
         port = int(config.port or get_default_port("mysql"))
         return pymysql.connect(

--- a/sqlit/install_strategy.py
+++ b/sqlit/install_strategy.py
@@ -158,7 +158,7 @@ def _get_arch_package_name(package_name: str) -> str | None:
         "psycopg2-binary": "python-psycopg2",
         "psycopg2": "python-psycopg2",
         "mssql-python": "python-mssql",
-        "mysql-connector-python": "python-mysql-connector",
+        "PyMySQL": "python-pymysql",
         "mariadb": "python-mariadb-connector",
         "oracledb": "python-oracledb",
         "duckdb": "python-duckdb",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -716,18 +716,18 @@ def mysql_db(mysql_server_ready: bool) -> str:
         pytest.skip("MySQL is not available")
 
     try:
-        import mysql.connector
+        import pymysql
     except ImportError:
-        pytest.skip("mysql-connector-python is not installed")
+        pytest.skip("PyMySQL is not installed")
 
     try:
-        conn = mysql.connector.connect(
+        conn = pymysql.connect(
             host=MYSQL_HOST,
             port=MYSQL_PORT,
             database=MYSQL_DATABASE,
             user=MYSQL_USER,
             password=MYSQL_PASSWORD,
-            connection_timeout=10,
+            connect_timeout=10,
         )
         cursor = conn.cursor()
 
@@ -793,13 +793,13 @@ def mysql_db(mysql_server_ready: bool) -> str:
     yield MYSQL_DATABASE
 
     try:
-        conn = mysql.connector.connect(
+        conn = pymysql.connect(
             host=MYSQL_HOST,
             port=MYSQL_PORT,
             database=MYSQL_DATABASE,
             user=MYSQL_USER,
             password=MYSQL_PASSWORD,
-            connection_timeout=10,
+            connect_timeout=10,
         )
         cursor = conn.cursor()
         cursor.execute("DROP TRIGGER IF EXISTS trg_test_users_audit")

--- a/tests/integration/python_packages/test_package_install_flow.py
+++ b/tests/integration/python_packages/test_package_install_flow.py
@@ -171,7 +171,7 @@ async def main() -> None:
     _assert_present("psycopg2")
 
     # Failure path: forced install failure yields manual instructions
-    _assert_missing("mysql.connector")
+    _assert_missing("pymysql")
     await _run_flow(force_fail=True, db_type="mysql")
 
 


### PR DESCRIPTION
- Update README, AUR files, and install_strategy.py to reference PyMySQL
- Update tests to use pymysql instead of mysql.connector
- Add migration detection for users with old mysql-connector-python installed
- Update mypy overrides for pymysql module