### PR TITLE
Add Azure AD Default authentication option

### DIFF
--- a/sqlit/domains/connections/providers/mssql/schema.py
+++ b/sqlit/domains/connections/providers/mssql/schema.py
@@ -19,6 +19,7 @@ def _get_mssql_auth_options() -> tuple[SelectOption, ...]:
         SelectOption("ad_password", "Azure AD Password"),
         SelectOption("ad_interactive", "Azure AD Interactive"),
         SelectOption("ad_integrated", "Azure AD Integrated"),
+        SelectOption("ad_default", "Azure AD Default (CLI)"),
     )
 
 


### PR DESCRIPTION
I was trying out your awesome solution, but it was not working in our working environment, because we rely on Azure CLI auth.

Found out, that this was already implemented, but not yet enabled in the UI.
This PR now enables the option also in the UI.

With that, I was successfully able to connect to our mysql databases with the Azure CLI as auth provider.