### PR TITLE
fix(typo): custom themes should be stored in `~/.sqlit/themes`

### DIFF
--- a/sqlit/domains/shell/app/theme_manager.py
+++ b/sqlit/domains/shell/app/theme_manager.py
@@ -34,7 +34,7 @@ from .themes import (
 )
 
 CUSTOM_THEME_SETTINGS_KEY = "custom_themes"
-CUSTOM_THEME_DIR = Path.home() / ".slit" / "themes"
+CUSTOM_THEME_DIR = Path.home() / ".sqlit" / "themes"
 CUSTOM_THEME_FIELDS = {
     "name",
     "primary",

--- a/sqlit/domains/shell/ui/screens/theme.py
+++ b/sqlit/domains/shell/ui/screens/theme.py
@@ -114,7 +114,7 @@ class CustomThemeScreen(ModalScreen[str | None]):
         shortcuts = [("Add", "<enter>"), ("Cancel", "<esc>")]
         with Dialog(id="custom-theme-dialog", title="Add Theme", shortcuts=shortcuts):
             yield Static(
-                "Enter theme name (template created in ~/.slit/themes/<name>.json):",
+                "Enter theme name (template created in ~/.sqlit/themes/<name>.json):",
                 id="custom-theme-description",
             )
             container = Container(id="custom-theme-container")


### PR DESCRIPTION
# Problem

Custom themes are stored in `~/.slit/themes` instead of `~/.sqlit/themes` which I believe is a typo

# Solution

Fix the typo to store custom themes in `~/.sqlit/themes`.