### PR TITLE
Add gruvbox-light theme

### DIFF
--- a/sqlit/domains/shell/app/themes.py
+++ b/sqlit/domains/shell/app/themes.py
@@ -26,6 +26,7 @@ LIGHT_THEME_NAMES = {
     "solarized-light",
     "catppuccin-latte",
     "rose-pine-dawn",
+    "gruvbox-light",
 }
 
 SQLIT_THEMES = [
@@ -70,6 +71,28 @@ SQLIT_THEMES = [
             "footer-key-foreground": "#1565C0",
             "button-color-foreground": "#FFFFFF",
             "input-selection-background": "#1565C0 25%",
+        },
+    ),
+    Theme(
+        name="gruvbox-light",
+        primary="#427B58",
+        secondary="#B57614",
+        accent="#427B58",
+        warning="#AF3A03",
+        error="#9D0006",
+        success="#79740E",
+        foreground="#3C3836",
+        background="#FBF1C7",
+        surface="#EBDBB2",
+        panel="#D5C4A1",
+        dark=False,
+        variables={
+            "border": "#BDAE93",
+            "block-cursor-foreground": "#282828",
+            "input-selection-background": "#68986640",
+            "button-color-foreground": "#FBF1C7",
+            "footer-background": "#EBDBB2",
+            "footer-key-foreground": "#427B58",
         },
     ),
     Theme(

--- a/sqlit/domains/shell/ui/screens/theme.py
+++ b/sqlit/domains/shell/ui/screens/theme.py
@@ -19,6 +19,7 @@ LIGHT_THEMES = {
     "sqlit-light": "Sqlit Light",
     "textual-light": "Textual Light",
     "solarized-light": "Solarized Light",
+    "gruvbox-light": "Gruvbox Light",
     "catppuccin-latte": "Catppuccin Latte",
     "rose-pine-dawn": "Rose Pine Dawn",
 }


### PR DESCRIPTION
### What
- Adds a light variant of the Gruvbox color scheme
- Registers `gruvbox-light` in the theme picker under "-- Light --" section