### PR TITLE
Add more basic VIM bindings for query editor: I, C, D

### DIFF
--- a/sqlit/core/keymap.py
+++ b/sqlit/core/keymap.py
@@ -329,6 +329,7 @@ class DefaultKeymapProvider(KeymapProvider):
             ActionKeyDef("question_mark", "show_help", "global"),
             # Query (normal mode)
             ActionKeyDef("i", "enter_insert_mode", "query_normal"),
+            ActionKeyDef("I", "prepend_insert_mode", "query_normal"),
             ActionKeyDef("o", "open_line_below", "query_normal"),
             ActionKeyDef("O", "open_line_above", "query_normal"),
             ActionKeyDef("enter", "execute_query", "query_normal"),

--- a/sqlit/domains/query/state/query_normal.py
+++ b/sqlit/domains/query/state/query_normal.py
@@ -38,6 +38,7 @@ class QueryNormalModeState(State):
         self.allows("cursor_find_char_back", help="Find char backward")
         self.allows("cursor_till_char", help="Move till char forward")
         self.allows("cursor_till_char_back", help="Move till char backward")
+        self.allows("prepend_insert_mode", help="Insert at line start")
         self.allows("append_insert_mode", help="Append after cursor")
         self.allows("append_line_end", help="Append at line end")
         # Vim open line

--- a/sqlit/domains/query/ui/mixins/query_editing_cursor.py
+++ b/sqlit/domains/query/ui/mixins/query_editing_cursor.py
@@ -118,6 +118,12 @@ class QueryEditingCursorMixin:
         """Move till after previous char (T{c})."""
         self._show_motion_char_pending_menu("T")
 
+    def action_prepend_insert_mode(self: QueryMixinHost) -> None:
+        """Enter insert mode at start of line (I)."""
+        row, _ = self.query_input.cursor_location
+        self.query_input.cursor_location = (row, 0)
+        self.action_enter_insert_mode()
+
     def action_append_insert_mode(self: QueryMixinHost) -> None:
         """Enter insert mode after cursor (a)."""
         lines = self.query_input.text.split("\n")

--- a/sqlit/domains/shell/state/machine.py
+++ b/sqlit/domains/shell/state/machine.py
@@ -185,7 +185,7 @@ class UIStateMachine:
         # ═══════════════════════════════════════════════════════════════════
         lines.append(section("QUERY EDITOR"))
         lines.append(subsection("Normal Mode:"))
-        lines.append(binding("i", "Enter INSERT mode"))
+        lines.append(binding("i/I", "Enter INSERT mode"))
         lines.append(binding("o/O", "Open line below/above"))
         lines.append(binding("C", "Change to line end"))
         lines.append(binding("D", "Delete to line end"))


### PR DESCRIPTION
Really great project - and very impressive, comprehensive implementation of a vim style editor!

I've been missing some basic vim actions though:
- "I" - insert at start of line
- "C" - change to end of line
- "D" - delete to end of line

Attached is my attempt to implement these actions with minimal changes.
I'm not very familiar with this project yet, so please let me know if anything doesn't fit the project guidelines.

Cheers,
Matthias