### PR TITLE
Fix navigating through search results in the explorer

### DIFF
--- a/sqlit/domains/explorer/ui/mixins/tree_filter.py
+++ b/sqlit/domains/explorer/ui/mixins/tree_filter.py
@@ -56,7 +56,17 @@ class TreeFilterMixin:
         self._update_footer_bindings()
 
     def action_tree_filter_accept(self: TreeFilterMixinHost) -> None:
-        """Accept current filter selection, close filter, and activate the node."""
+        """Accept filter:
+        First action: activate filter, enter navigation mode.
+        Second action: close filter, and activate the node.
+        """
+
+        # On first accept: switch to navigation mode (keep filter open)
+        if self._tree_filter_visible and self._tree_filter_typing:
+            self._tree_filter_typing = False
+            self._jump_to_current_match()
+            return
+
         # Store current match before closing
         current_node = None
         if self._tree_filter_matches and self._tree_filter_match_index < len(self._tree_filter_matches):


### PR DESCRIPTION
I believe there's currently a bug with the filter feature in the connection exporer.
It doesn't seem possible to jump to the next or previous search result, even though there's some code which mostly already implements this.

The problem seems to be that both `_tree_filter_visible` and `_tree_filter_typing` are always toggled on/off at the same time.
Therefore the code to activate the navigation (`action_tree_filter_next` / `_prev`) is never reached.

This MR is a crude suggestion on how to quickly fix this.
The idea is that on the first "enter", we set only the `_tree_filter_typing` to false, meaning that we're in "navigation" mode.
Then on the second "enter", we also set the `_tree_filter_visible` to false and activate the selected item.

I don't think this is the ideal solution as there should be some visual cues or help shown to make the behaviour more obvious.
(Or maybe we even want a wholly different approach, e.g. to stay in "typing" mode at all times and use C-n / C-N to cycle through the results.)
Still, I think with this fix it's better than the current behaviour.
Let me know what you think on where we should take this topic.