### PR TITLE
Add Supabase pooler shard option

### DIFF
--- a/sqlit/cli.py
+++ b/sqlit/cli.py
@@ -295,6 +295,10 @@ def main() -> int:
     parser.add_argument("--supabase-region", help="Supabase region (temporary connection)")
     parser.add_argument("--supabase-project-id", help="Supabase project id (temporary connection)")
     parser.add_argument(
+        "--supabase-aws-shard",
+        help="Supabase pooler shard prefix (temporary connection, e.g. aws-0, aws-1)",
+    )
+    parser.add_argument(
         "--settings",
         metavar="PATH",
         help="Path to settings JSON file (overrides ~/.sqlit/settings.json)",

--- a/sqlit/domains/connections/providers/supabase/adapter.py
+++ b/sqlit/domains/connections/providers/supabase/adapter.py
@@ -20,8 +20,16 @@ class SupabaseAdapter(PostgreSQLAdapter):
     def connect(self, config: ConnectionConfig) -> Any:
         region = config.get_option("supabase_region", "")
         project_id = config.get_option("supabase_project_id", "")
+        shard = config.get_option("supabase_aws_shard", "aws-0")
+        shard = str(shard).strip() or "aws-0"
+        if shard.startswith("aws") and not shard.startswith("aws-"):
+            suffix = shard.removeprefix("aws")
+            if suffix.isdigit():
+                shard = f"aws-{suffix}"
+        elif shard.isdigit():
+            shard = f"aws-{shard}"
         transformed = config.with_endpoint(
-            host=f"aws-0-{region}.pooler.supabase.com",
+            host=f"{shard}-{region}.pooler.supabase.com",
             port="5432",
             username=f"postgres.{project_id}",
             database="postgres",

--- a/sqlit/domains/connections/providers/supabase/schema.py
+++ b/sqlit/domains/connections/providers/supabase/schema.py
@@ -27,6 +27,13 @@ SCHEMA = ConnectionSchema(
             required=True,
         ),
         SchemaField(
+            name="supabase_aws_shard",
+            label="AWS Shard",
+            placeholder="aws-0",
+            default="aws-0",
+            description="Pooler shard prefix (e.g. aws-0, aws-1)",
+        ),
+        SchemaField(
             name="password",
             label="Password",
             field_type=FieldType.PASSWORD,


### PR DESCRIPTION
## Summary\n- add a Supabase pooler shard option (e.g. aws-0/aws-1)\n- use the shard when building the pooler host\n- expose a CLI flag for temporary Supabase connections\n\n## Motivation\nSome Supabase projects live on aws-1-* poolers; hardcoding aws-0 causes tenant/user not found errors.\n\n## Testing\n- not run (config/host construction change only)