### PR TITLE
fix: move Commands hint to left side for better discoverability

### DIFF
--- a/sqlit/domains/shell/state/main_screen.py
+++ b/sqlit/domains/shell/state/main_screen.py
@@ -21,7 +21,7 @@ class MainScreenState(State):
         self.allows("show_help", key="?", label="Help", right=True)
         self.allows("change_theme")
         self.allows("toggle_process_worker", help="Toggle process worker")
-        self.allows("leader_key", key="<space>", label="Leader", right=True)
+        self.allows("leader_key", key="<space>", label="Commands")
 
     def is_active(self, app: InputContext) -> bool:
         if app.modal_open:


### PR DESCRIPTION
## Summary

Fixes #83

The 'Commands' hint was positioned at the far right of the status bar using `right=True`, making it nearly invisible to users. Many users reported not being able to find how to quit the application.

## Problem

```
┌────────────────────────────────────────────────────────────────────────────┐
│  [Filter] [Navigation hints...]                                  Commands │
└────────────────────────────────────────────────────────────────────────────┘
                                                                    ↑ Hidden!
```

## Solution

Remove `right=True` from the leader_key binding so the hint appears on the left with other hints:

```python
# Before
self.allows("leader_key", key="<space>", label="Leader", right=True)

# After
self.allows("leader_key", key="<space>", label="Commands")
```

Also renamed the label from 'Leader' to 'Commands' for clarity.

## Result

```
┌────────────────────────────────────────────────────────────────────────────┐
│  [Commands] [Filter] [Navigation hints...]                                 │
└────────────────────────────────────────────────────────────────────────────┘
    ↑ Visible!
```

## Testing

All 11 related tests pass.