### PR TITLE
feat: add toggle comment selection (g+c+s)

### DIFF
--- a/sqlit/core/keymap.py
+++ b/sqlit/core/keymap.py
@@ -281,6 +281,7 @@ class DefaultKeymapProvider(KeymapProvider):
             LeaderCommandDef("j", "down", "Comment line down", "Comment", menu="gc"),
             LeaderCommandDef("k", "up", "Comment line up", "Comment", menu="gc"),
             LeaderCommandDef("G", "to_end", "Comment to end", "Comment", menu="gc"),
+            LeaderCommandDef("s", "selection", "Toggle selection", "Comment", menu="gc"),
             # ry results yank menu
             LeaderCommandDef("c", "cell", "Copy cell", "Copy", menu="ry"),
             LeaderCommandDef("y", "row", "Copy row", "Copy", menu="ry"),

--- a/sqlit/domains/query/ui/mixins/query_editing_comments.py
+++ b/sqlit/domains/query/ui/mixins/query_editing_comments.py
@@ -65,3 +65,28 @@ class QueryEditingCommentsMixin:
         new_text, new_col = toggle_comment_lines(text, row, end_row)
         self.query_input.text = new_text
         self.query_input.cursor_location = (row, new_col)
+
+    def action_gc_selection(self: QueryMixinHost) -> None:
+        """Toggle comment on currently selected text (gcs)."""
+        self._clear_leader_pending()
+
+        if not self._has_selection():
+            return
+
+        self._push_undo_state()
+        from sqlit.domains.query.editing.comments import toggle_comment_lines
+
+        selection = self.query_input.selection
+        start, end = self._ordered_selection(selection)
+
+        start_row = start[0]
+        end_row = end[0]
+
+        # If selection ends at the start of a line, don't include that line
+        if end[1] == 0 and end_row > start_row:
+            end_row -= 1
+
+        text = self.query_input.text
+        new_text, new_col = toggle_comment_lines(text, start_row, end_row)
+        self.query_input.text = new_text
+        self.query_input.cursor_location = (start_row, new_col)

--- a/tests/unit/test_comments.py
+++ b/tests/unit/test_comments.py
@@ -129,3 +129,46 @@ class TestToggleCommentLines:
         new_text, col = toggle_comment_lines(text, 0, 0)
         assert new_text == "\t-- SELECT * FROM users"
         assert col == 4  # 1 tab + "-- "
+
+    @pytest.mark.parametrize(
+        "text, start_row, end_row, expected_text, expected_col",
+        [
+            # Toggle on: simple multi-line
+            (
+                "SELECT *\nFROM users",
+                0,
+                1,
+                "-- SELECT *\n-- FROM users",
+                3,
+            ),
+            # Toggle off: simple multi-line
+            (
+                "-- SELECT *\n-- FROM users",
+                0,
+                1,
+                "SELECT *\nFROM users",
+                0,
+            ),
+            # Toggle on: mixed content (first line uncommented -> comment all)
+            (
+                "SELECT *\n-- FROM users",
+                0,
+                1,
+                "-- SELECT *\n-- -- FROM users",
+                3,
+            ),
+            # Toggle off: mixed content (first line commented -> uncomment all)
+            (
+                "-- SELECT *\nFROM users",
+                0,
+                1,
+                "SELECT *\nFROM users",
+                0,
+            ),
+        ],
+    )
+    def test_toggle_scenarios_parametrized(self, text, start_row, end_row, expected_text, expected_col):
+        """Test various toggle scenarios mimicking selection behavior."""
+        new_text, col = toggle_comment_lines(text, start_row, end_row)
+        assert new_text == expected_text
+        assert col == expected_col


### PR DESCRIPTION
## Summary
- Adds `g+c+s` keyboard shortcut to toggle comments on the currently selected text in the query editor
- Implements `action_gc_selection` in QueryEditingCommentsMixin
