### PR TITLE
fix: make MotherDuck database field optional

### DIFF
--- a/sqlit/domains/connections/providers/motherduck/adapter.py
+++ b/sqlit/domains/connections/providers/motherduck/adapter.py
@@ -37,20 +37,24 @@ class MotherDuckAdapter(DuckDBAdapter):
             package_name=self.install_package,
         )
 
-        # Get default database from options
-        database = config.get_option("default_database", "")
+        # Get database from endpoint (optional - empty means browse all)
+        database = ""
+        if config.tcp_endpoint:
+            database = config.tcp_endpoint.database or ""
 
         # Get token from tcp_endpoint.password (stored in keyring)
         token = ""
         if config.tcp_endpoint:
             token = config.tcp_endpoint.password or ""
 
-        if not database:
-            raise ValueError("MotherDuck connections require a database name.")
         if not token:
             raise ValueError("MotherDuck connections require an access token.")
 
-        conn_str = f"md:{database}?motherduck_token={token}"
+        # Connect with or without specific database
+        if database:
+            conn_str = f"md:{database}?motherduck_token={token}"
+        else:
+            conn_str = f"md:?motherduck_token={token}"
 
         duckdb_any: Any = duckdb
         return duckdb_any.connect(conn_str)

--- a/sqlit/domains/connections/providers/motherduck/schema.py
+++ b/sqlit/domains/connections/providers/motherduck/schema.py
@@ -11,10 +11,10 @@ SCHEMA = ConnectionSchema(
     display_name="MotherDuck",
     fields=(
         SchemaField(
-            name="default_database",
-            label="Default Database",
-            placeholder="my_database",
-            required=True,
+            name="database",
+            label="Database",
+            placeholder="(empty = browse all)",
+            required=False,
         ),
         SchemaField(
             name="password",

--- a/tests/unit/test_motherduck_adapter.py
+++ b/tests/unit/test_motherduck_adapter.py
@@ -36,16 +36,16 @@ def test_motherduck_schema_uses_password_field():
     from sqlit.domains.connections.providers.motherduck.schema import SCHEMA
 
     field_names = [f.name for f in SCHEMA.fields]
-    assert "default_database" in field_names
+    assert "database" in field_names
     assert "password" in field_names  # Uses standard password field for token
 
     # Password field should be labeled as "Access Token"
     password_field = next(f for f in SCHEMA.fields if f.name == "password")
     assert password_field.label == "Access Token"
 
-    # Database field should be labeled as "Default Database"
-    db_field = next(f for f in SCHEMA.fields if f.name == "default_database")
-    assert db_field.label == "Default Database"
+    # Database field should be optional (empty = browse all)
+    db_field = next(f for f in SCHEMA.fields if f.name == "database")
+    assert db_field.required is False
 
 
 def test_motherduck_supports_multiple_databases():


### PR DESCRIPTION
## Summary
- Empty database field = browse all MotherDuck databases (shows Databases folder)
- Set database = show only that database's tables
- Reverts from `default_database` back to standard `database` field

Follow-up fix to PR #119.