### PR TITLE
fix: teradata adapter + resultset

### DIFF
--- a/sqlit/domains/connections/providers/teradata/adapter.py
+++ b/sqlit/domains/connections/providers/teradata/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 from sqlit.domains.connections.providers.adapters.base import (
@@ -47,6 +48,28 @@ class TeradataAdapter(CursorBasedAdapter):
     @property
     def supports_stored_procedures(self) -> bool:
         return True
+
+    _TERADATA_SELECT_KEYWORDS = frozenset(
+        {"SELECT", "SEL", "WITH", "SHOW", "DESCRIBE", "EXPLAIN", "HELP"}
+    )
+
+    _LOCKING_RE = re.compile(
+        r"\bFOR\s+(?:ACCESS|READ|WRITE|EXCLUSIVE)(?:\s+NOWAIT)?\s+(\w+)",
+        re.IGNORECASE,
+    )
+
+    def classify_query(self, query: str) -> bool:
+        """Classify Teradata queries, handling LOCKING/LOCK prefix and SEL abbreviation."""
+        query_upper = query.strip().upper()
+        first_word = query_upper.split()[0] if query_upper else ""
+
+        # Strip LOCKING/LOCK request modifier to find the actual statement keyword
+        if first_word in ("LOCKING", "LOCK"):
+            match = self._LOCKING_RE.search(query_upper)
+            if match:
+                first_word = match.group(1)
+
+        return first_word in self._TERADATA_SELECT_KEYWORDS
 
     def apply_database_override(self, config: ConnectionConfig, database: str) -> ConnectionConfig:
         """Apply a default database for unqualified queries."""

--- a/sqlit/domains/query/app/query_service.py
+++ b/sqlit/domains/query/app/query_service.py
@@ -68,9 +68,10 @@ class KeywordQueryAnalyzer:
     def classify(self, query: str) -> QueryKind:
         """Classify query based on keyword of the last statement.
 
-        For multi-statement queries like 'BEGIN; INSERT...; SELECT * FROM t;',
-        we check the last statement to determine if results should be returned.
-        Uses the same splitting logic as multi_statement.split_statements.
+        Enhanced for Teradata:
+        - Supports SEL (Teradata abbreviation for SELECT)
+        - Supports HELP statements
+        - Handles LOCKING ... SELECT patterns (common in Teradata)
         """
         from sqlit.domains.query.editing.comments import (
             is_comment_line,
@@ -87,16 +88,21 @@ class KeywordQueryAnalyzer:
         for stmt in reversed(statements):
             if is_comment_only_statement(stmt):
                 continue
-            # Found a statement with actual SQL - get first non-comment line
+            # Get first non-comment line
             lines = [line.strip() for line in stmt.split("\n") if line.strip()]
             non_comment_lines = [line for line in lines if not is_comment_line(line)]
             if non_comment_lines:
-                first_line = non_comment_lines[0].upper()
-                first_word = first_line.split()[0] if first_line else ""
+                first_line_upper = non_comment_lines[0].upper()
+
+                # Teradata-specific patterns (word-boundary aware)
+                if re.search(r"\b(SELECT|WITH|SHOW|DESCRIBE|EXPLAIN|PRAGMA|SEL|HELP)\b", first_line_upper):
+                    return QueryKind.RETURNS_ROWS
+
+                # Fallback to original first-word check
+                first_word = first_line_upper.split()[0] if first_line_upper else ""
                 return QueryKind.RETURNS_ROWS if first_word in SELECT_KEYWORDS else QueryKind.NON_QUERY
 
         return QueryKind.NON_QUERY
-
 
 class DialectQueryAnalyzer:
     def __init__(self, dialect: Any, fallback: QueryAnalyzer | None = None) -> None:

--- a/sqlit/domains/query/app/query_service.py
+++ b/sqlit/domains/query/app/query_service.py
@@ -68,10 +68,9 @@ class KeywordQueryAnalyzer:
     def classify(self, query: str) -> QueryKind:
         """Classify query based on keyword of the last statement.
 
-        Enhanced for Teradata:
-        - Supports SEL (Teradata abbreviation for SELECT)
-        - Supports HELP statements
-        - Handles LOCKING ... SELECT patterns (common in Teradata)
+        For multi-statement queries like 'BEGIN; INSERT...; SELECT * FROM t;',
+        we check the last statement to determine if results should be returned.
+        Uses the same splitting logic as multi_statement.split_statements.
         """
         from sqlit.domains.query.editing.comments import (
             is_comment_line,
@@ -88,21 +87,16 @@ class KeywordQueryAnalyzer:
         for stmt in reversed(statements):
             if is_comment_only_statement(stmt):
                 continue
-            # Get first non-comment line
+            # Found a statement with actual SQL - get first non-comment line
             lines = [line.strip() for line in stmt.split("\n") if line.strip()]
             non_comment_lines = [line for line in lines if not is_comment_line(line)]
             if non_comment_lines:
-                first_line_upper = non_comment_lines[0].upper()
-
-                # Teradata-specific patterns (word-boundary aware)
-                if re.search(r"\b(SELECT|WITH|SHOW|DESCRIBE|EXPLAIN|PRAGMA|SEL|HELP)\b", first_line_upper):
-                    return QueryKind.RETURNS_ROWS
-
-                # Fallback to original first-word check
-                first_word = first_line_upper.split()[0] if first_line_upper else ""
+                first_line = non_comment_lines[0].upper()
+                first_word = first_line.split()[0] if first_line else ""
                 return QueryKind.RETURNS_ROWS if first_word in SELECT_KEYWORDS else QueryKind.NON_QUERY
 
         return QueryKind.NON_QUERY
+
 
 class DialectQueryAnalyzer:
     def __init__(self, dialect: Any, fallback: QueryAnalyzer | None = None) -> None:


### PR DESCRIPTION
Fixing some non working teradata queries
Adding `lock row for access` (a bit faster depending on the configuration of the user)
Removing part with sequences (it does not exist in Teradata)

hack to display resultsets for queries otherwise it was always considered a NON_QUERY so only the affected rows was displayed.
This part should be fixed properly but I don't know how, at least this way it's usable with Teradata

Edit : The last part is not working because of the keyword list in SELECT_KEYWORD, in teradata, it can start with a locking modifier like (lock, locking etc...)
Would it be possible to recognize the type of statement based on tree-sitter parser for instance ?