### PR TITLE
Allow "e"button to move to end of word, make E go to Explorer Pane

### DIFF
--- a/sqlit/core/keymap.py
+++ b/sqlit/core/keymap.py
@@ -187,7 +187,7 @@ class DefaultKeymapProvider(KeymapProvider):
     def _build_leader_commands(self) -> list[LeaderCommandDef]:
         return [
             # View
-            LeaderCommandDef("e", "toggle_explorer", "Toggle Explorer", "View"),
+            LeaderCommandDef("E", "toggle_explorer", "Toggle Explorer", "View"),
             LeaderCommandDef("f", "toggle_fullscreen", "Toggle Maximize", "View"),
             # Connection
             LeaderCommandDef("c", "show_connection_picker", "Connect", "Connection"),
@@ -370,8 +370,9 @@ class DefaultKeymapProvider(KeymapProvider):
             ActionKeyDef("escape", "exit_insert_mode", "query_insert"),
             ActionKeyDef("ctrl+enter", "execute_query_insert", "query_insert"),
             ActionKeyDef("tab", "autocomplete_accept", "query_insert"),
+            ActionKeyDef("e", "cursor_word_end", "query_normal"),
             # Navigation
-            ActionKeyDef("e", "focus_explorer", "navigation"),
+            ActionKeyDef("E", "focus_explorer", "navigation"),
             ActionKeyDef("q", "focus_query", "navigation"),
             ActionKeyDef("r", "focus_results", "navigation"),
             # Query (autocomplete)

--- a/sqlit/domains/query/state/query_normal.py
+++ b/sqlit/domains/query/state/query_normal.py
@@ -29,6 +29,7 @@ class QueryNormalModeState(State):
         self.allows("cursor_down", help="Move cursor down")
         self.allows("cursor_word_forward", help="Move to next word")
         self.allows("cursor_WORD_forward", help="Move to next WORD")
+        self.allows("cursor_word_end", help="Move to word end")
         self.allows("cursor_word_back", help="Move to previous word")
         self.allows("cursor_WORD_back", help="Move to previous WORD")
         self.allows("cursor_line_start", help="Move to line start")

--- a/sqlit/domains/query/ui/mixins/query_editing_cursor.py
+++ b/sqlit/domains/query/ui/mixins/query_editing_cursor.py
@@ -99,6 +99,10 @@ class QueryEditingCursorMixin:
         """Move cursor to next WORD (W)."""
         self._move_with_motion("W")
 
+    def action_cursor_word_end(self: QueryMixinHost) -> None:
+        """Move cursor to end of word (e)."""
+        self._move_with_motion("e")
+
     def action_cursor_word_back(self: QueryMixinHost) -> None:
         """Move cursor to previous word (b)."""
         self._move_with_motion("b")

--- a/sqlit/domains/shell/state/machine.py
+++ b/sqlit/domains/shell/state/machine.py
@@ -164,7 +164,7 @@ class UIStateMachine:
         # NAVIGATION
         # ═══════════════════════════════════════════════════════════════════
         lines.append(section("NAVIGATION"))
-        lines.append(binding("e", "Focus Explorer pane"))
+        lines.append(binding("E", "Focus Explorer pane"))
         lines.append(binding("q", "Focus Query pane"))
         lines.append(binding("r", "Focus Results pane"))
         lines.append(binding(leader_key, "Open command menu"))
@@ -223,6 +223,7 @@ class UIStateMachine:
         lines.append(subsection("Vim Motions:"))
         lines.append(binding("h/j/k/l", "Cursor left/down/up/right"))
         lines.append(binding("w/W", "Word forward"))
+        lines.append(binding("e", "Word end"))
         lines.append(binding("b/B", "Word backward"))
         lines.append(binding("0/$", "Line start/end"))
         lines.append(binding("gg/G", "File start/end"))


### PR DESCRIPTION
Hi,

I know this is a bit of a silly PR, but essentially, my finger memory for vim is that "e" is end-of-word, and I keep doing the wrong thing, jumping to the Explorer pane. So I created this PR. Of course this is a bit silly. But maybe we could have a configurable set of keybindings that would allow "e" to be reconfigured to these two things, so I can use sqlit as-is :) Also, the README lacks an example how to re-configure keybindings, maybe that could be added? I literally found it easier to do this than to figure out how to configure it...

Thanks, and let me know what you think,

Mate

PS: I am not always this silly, I write some serious code, but I thought this could be kind of a bit of an inspiration :)