### PR TITLE
Add x and caret

### DIFF
--- a/sqlit/core/keymap.py
+++ b/sqlit/core/keymap.py
@@ -11,6 +11,7 @@ KEY_DISPLAY_OVERRIDES: dict[str, str] = {
     "question_mark": "?",
     "slash": "/",
     "asterisk": "*",
+    "circumflex_accent": "^",
     "dollar_sign": "$",
     "percent_sign": "%",
     "space": "<space>",
@@ -357,6 +358,7 @@ class DefaultKeymapProvider(KeymapProvider):
             ActionKeyDef("b", "cursor_word_back", "query_normal"),
             ActionKeyDef("B", "cursor_WORD_back", "query_normal"),
             ActionKeyDef("0", "cursor_line_start", "query_normal"),
+            ActionKeyDef("circumflex_accent", "cursor_first_non_blank", "query_normal"),
             ActionKeyDef("dollar_sign", "cursor_line_end", "query_normal"),
             ActionKeyDef("G", "cursor_last_line", "query_normal"),
             ActionKeyDef("percent_sign", "cursor_matching_bracket", "query_normal"),
@@ -364,6 +366,7 @@ class DefaultKeymapProvider(KeymapProvider):
             ActionKeyDef("F", "cursor_find_char_back", "query_normal"),
             ActionKeyDef("t", "cursor_till_char", "query_normal"),
             ActionKeyDef("T", "cursor_till_char_back", "query_normal"),
+            ActionKeyDef("x", "delete_char", "query_normal"),
             ActionKeyDef("a", "append_insert_mode", "query_normal"),
             ActionKeyDef("A", "append_line_end", "query_normal"),
             # Query (insert mode)

--- a/sqlit/domains/query/editing/motions/lines.py
+++ b/sqlit/domains/query/editing/motions/lines.py
@@ -22,6 +22,24 @@ def motion_line_start(
     )
 
 
+def motion_first_non_blank(
+    text: str, row: int, col: int, char: str | None = None
+) -> MotionResult:
+    """Move to first non-whitespace character on line (^)."""
+    lines, row, col = _normalize(text, row, col)
+    line = lines[row]
+    first_col = len(line) - len(line.lstrip())
+    return MotionResult(
+        position=Position(row, first_col),
+        range=Range(
+            Position(row, min(col, first_col)),
+            Position(row, max(col, first_col)),
+            MotionType.CHARWISE,
+            inclusive=False,
+        ),
+    )
+
+
 def motion_line_end(
     text: str, row: int, col: int, char: str | None = None
 ) -> MotionResult:

--- a/sqlit/domains/query/editing/motions/registry.py
+++ b/sqlit/domains/query/editing/motions/registry.py
@@ -8,6 +8,7 @@ from .brackets import motion_matching_bracket
 from .lines import (
     motion_current_line,
     motion_first_line,
+    motion_first_non_blank,
     motion_last_line,
     motion_line_end,
     motion_line_start,
@@ -42,6 +43,7 @@ MOTIONS: dict[str, MotionFunc] = {
     "e": motion_word_end,
     "E": motion_WORD_end,
     "0": motion_line_start,
+    "^": motion_first_non_blank,
     "$": motion_line_end,
     "G": motion_last_line,
     "gg": motion_first_line,  # Go to first line

--- a/sqlit/domains/query/state/query_normal.py
+++ b/sqlit/domains/query/state/query_normal.py
@@ -31,6 +31,7 @@ class QueryNormalModeState(State):
         self.allows("cursor_WORD_forward", help="Move to next WORD")
         self.allows("cursor_word_back", help="Move to previous word")
         self.allows("cursor_WORD_back", help="Move to previous WORD")
+        self.allows("cursor_first_non_blank", help="Move to first non-blank")
         self.allows("cursor_line_start", help="Move to line start")
         self.allows("cursor_line_end", help="Move to line end")
         self.allows("cursor_last_line", help="Move to last line")
@@ -45,6 +46,8 @@ class QueryNormalModeState(State):
         # Vim open line
         self.allows("open_line_below", help="Open line below")
         self.allows("open_line_above", help="Open line above")
+        # Vim delete char
+        self.allows("delete_char", help="Delete character under cursor")
         # Vim delete or change
         self.allows("change_line_end_motion", help="Change to line end")
         self.allows("delete_line_end", help="Delete to line end")

--- a/sqlit/domains/query/ui/mixins/query_editing_cursor.py
+++ b/sqlit/domains/query/ui/mixins/query_editing_cursor.py
@@ -107,6 +107,10 @@ class QueryEditingCursorMixin:
         """Move cursor to previous WORD (B)."""
         self._move_with_motion("B")
 
+    def action_cursor_first_non_blank(self: QueryMixinHost) -> None:
+        """Move cursor to first non-whitespace character (^)."""
+        self._move_with_motion("^")
+
     def action_cursor_line_start(self: QueryMixinHost) -> None:
         """Move cursor to start of line (0)."""
         self._move_with_motion("0")

--- a/sqlit/domains/shell/state/machine.py
+++ b/sqlit/domains/shell/state/machine.py
@@ -224,7 +224,7 @@ class UIStateMachine:
         lines.append(binding("h/j/k/l", "Cursor left/down/up/right"))
         lines.append(binding("w/W", "Word forward"))
         lines.append(binding("b/B", "Word backward"))
-        lines.append(binding("0/$", "Line start/end"))
+        lines.append(binding("0/^/$", "Line start/first char/end"))
         lines.append(binding("gg/G", "File start/end"))
         lines.append(binding("f{c}/F{c}", "Find char forward/back"))
         lines.append(binding("t{c}/T{c}", "Till char forward/back"))

--- a/tests/unit/test_vim_motions.py
+++ b/tests/unit/test_vim_motions.py
@@ -212,7 +212,7 @@ class TestMotionRegistry:
         expected = {
             "h", "j", "k", "l",
             "w", "W", "b", "B", "e", "E",
-            "0", "$", "G", "gg", "ge", "gE", "_",
+            "0", "^", "$", "G", "gg", "ge", "gE", "_",
             "f", "F", "t", "T",
             "%",
         }


### PR DESCRIPTION
This PR allows "^" and "x" keybindings for non-insert mode, which correspond to the vim keybindings -- goto first printable character and delete character under cursor. Should hopefully be non-controversial :)