### PR TITLE
Restrict Python to 3.12 due to psycopg2 crashes on 3.13+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sqlit-tui"
 description = "A terminal UI for SQL Server, PostgreSQL, MySQL, SQLite, Oracle, and more"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 authors = [
     { name = "Peter" }
 ]
@@ -22,7 +22,6 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Topic :: Database",
 ]
 dependencies = [


### PR DESCRIPTION
Narrowing Python version down to 3.12 due to psycopg2-binary instability on 3.13 and above.