### PR TITLE
fix: install postgres driver in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
           SETUPTOOLS_SCM_PRETEND_VERSION = version;
 
           dependencies = [
+            pyPkgs.psycopg2-binary
             pyPkgs.docker
             pyPkgs.keyring
             pyPkgs.pyperclip


### PR DESCRIPTION
Currently when starting the nix flake pip is not installed so its not possible to install the missing Postgres driver.