### PR TITLE
Show column headers for queries that return zero rows

### DIFF
--- a/sqlit/domains/query/ui/mixins/query_results.py
+++ b/sqlit/domains/query/ui/mixins/query_results.py
@@ -72,6 +72,28 @@ class QueryResultsMixin:
             )
 
         render_rows = rows[:MAX_RENDER_ROWS] if rows else []
+        if not render_rows:
+            # An empty `data=[]` yields a backend with no columns, so column
+            # labels never render. Build an Arrow backend with the right
+            # schema so headers still appear for zero-row results.
+            import pyarrow as pa
+            from textual_fastdatatable.backend import ArrowBackend
+
+            empty_backend = ArrowBackend(
+                pa.Table.from_arrays(
+                    [pa.array([], type=pa.string()) for _ in columns],
+                    names=list(columns),
+                )
+            )
+            return SqlitDataTable(
+                id=new_id,
+                zebra_stripes=True,
+                backend=empty_backend,
+                column_labels=columns,
+                max_column_content_width=MAX_COLUMN_CONTENT_WIDTH,
+                render_markup=render_markup,
+                null_rep="NULL",
+            )
         return SqlitDataTable(
             id=new_id,
             zebra_stripes=True,

--- a/sqlit/shared/ui/widgets_tables.py
+++ b/sqlit/shared/ui/widgets_tables.py
@@ -35,8 +35,9 @@ class SqlitDataTable(FastDataTable):
 
     def action_copy_selection(self) -> None:
         """Copy selection to clipboard, guarding against empty tables."""
-        # Guard against empty table - the library doesn't check this
-        if self.backend is None:
+        # Guard against empty table - the library doesn't check this.
+        # A schema-only backend (columns but no rows) still has backend != None.
+        if self.backend is None or self.backend.row_count == 0:
             return
         # Call parent implementation
         super().action_copy_selection()


### PR DESCRIPTION
When a query returned 0 rows, the results pane went completely blank — not even the column headers showed. Root cause: passing `data=[]` to `SqlitDataTable` built an Arrow backend with no columns, so `ordered_columns` zipped against zero content-widths and produced an empty list.

Fix: when rows are empty but columns are known, build the backend from an empty Arrow table carrying the right schema so headers render.

Also had to guard `action_copy_selection` — with a schema-only backend, `backend` is no longer `None` but `row_count == 0`, and the upstream copy path indexed into a non-existent row.