### PR TITLE
Expose optional DB drivers in the Nix flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pip install sqlit-tui
 # Arch Linux (AUR)
 yay -S sqlit
 
-# Nix (flake) — append "#sqlit-full" for common DB drivers
+# Nix (flake)
 nix run github:Maxteabag/sqlit
 ```
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pip install sqlit-tui
 # Arch Linux (AUR)
 yay -S sqlit
 
-# Nix (flake)
+# Nix (flake) — append "#sqlit-full" for common DB drivers
 nix run github:Maxteabag/sqlit
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -98,11 +98,10 @@
             };
           };
 
-        sqlit = makeSqlit { };
-        sqlit-full = makeSqlit { extras = builtins.attrNames nixpkgsExtras; };
+        sqlit = makeSqlit { extras = builtins.attrNames nixpkgsExtras; };
       in {
         packages = {
-          inherit sqlit sqlit-full;
+          inherit sqlit;
           default = sqlit;
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,52 +28,85 @@
         shortRev = if self ? shortRev then self.shortRev else "dirty";
         version = if tag != "" then tag else "0.0.0+${shortRev}";
 
-        sqlit = pyPkgs.buildPythonApplication {
-          pname = "sqlit";
-          inherit version;
-          pyproject = true;
-
-          src = self;
-
-          build-system = [
-            pyPkgs.hatchling
-            pyPkgs."hatch-vcs"
-            pyPkgs."setuptools-scm"
-          ];
-
-          nativeBuildInputs = [
-            pyPkgs.pythonRelaxDepsHook
-          ];
-
-          pythonRelaxDeps = [
-            "textual-fastdatatable"
-          ];
-
-          SETUPTOOLS_SCM_PRETEND_VERSION = version;
-
-          dependencies = [
-            pyPkgs.docker
-            pyPkgs.keyring
-            pyPkgs.pyperclip
-            pyPkgs.sqlparse
-            pyPkgs.textual
-            pyPkgs."textual-fastdatatable"
-          ];
-
-          pythonImportsCheck = [ "sqlit" ];
-
-          meta = with lib; {
-            description = "A terminal UI for SQL databases";
-            homepage = "https://github.com/Maxteabag/sqlit";
-            license = licenses.mit;
-            mainProgram = "sqlit";
-          };
+        # Extras mirror project.optional-dependencies in pyproject.toml,
+        # limited to drivers packaged in nixpkgs. Others (mssql-python,
+        # oracledb, mariadb, ibm_db, hdbcli, teradatasql, trino,
+        # presto-python-client, redshift-connector, clickhouse-connect,
+        # libsql, firebirdsql, pyathena, adbc-driver-flightsql) aren't
+        # here; install with `pipx inject` or a custom derivation.
+        nixpkgsExtras = {
+          ssh = [ pyPkgs.sshtunnel pyPkgs.paramiko ];
+          postgres = [ pyPkgs.psycopg2 ];
+          cockroachdb = [ pyPkgs.psycopg2 ];
+          mysql = [ pyPkgs.pymysql ];
+          duckdb = [ pyPkgs.duckdb ];
+          bigquery = [ pyPkgs.google-cloud-bigquery ];
+          snowflake = [ pyPkgs.snowflake-connector-python ];
+          d1 = [ pyPkgs.requests ];
         };
+
+        resolveExtras = names:
+          lib.concatLists (map (n:
+            nixpkgsExtras.${n} or (throw
+              "Unknown sqlit extra '${n}'. Available: ${
+                lib.concatStringsSep ", " (builtins.attrNames nixpkgsExtras)
+              }")
+          ) names);
+
+        # Build sqlit, optionally with a set of driver extras from nixpkgs.
+        # Example:  makeSqlit { extras = [ "postgres" "ssh" ]; }
+        makeSqlit = { extras ? [] }:
+          pyPkgs.buildPythonApplication {
+            pname = "sqlit";
+            inherit version;
+            pyproject = true;
+
+            src = self;
+
+            build-system = [
+              pyPkgs.hatchling
+              pyPkgs."hatch-vcs"
+              pyPkgs."setuptools-scm"
+            ];
+
+            nativeBuildInputs = [
+              pyPkgs.pythonRelaxDepsHook
+            ];
+
+            pythonRelaxDeps = [
+              "textual-fastdatatable"
+            ];
+
+            SETUPTOOLS_SCM_PRETEND_VERSION = version;
+
+            dependencies = [
+              pyPkgs.docker
+              pyPkgs.keyring
+              pyPkgs.pyperclip
+              pyPkgs.sqlparse
+              pyPkgs.textual
+              pyPkgs."textual-fastdatatable"
+            ] ++ (resolveExtras extras);
+
+            pythonImportsCheck = [ "sqlit" ];
+
+            meta = with lib; {
+              description = "A terminal UI for SQL databases";
+              homepage = "https://github.com/Maxteabag/sqlit";
+              license = licenses.mit;
+              mainProgram = "sqlit";
+            };
+          };
+
+        sqlit = makeSqlit { };
+        sqlit-full = makeSqlit { extras = builtins.attrNames nixpkgsExtras; };
       in {
         packages = {
-          inherit sqlit;
+          inherit sqlit sqlit-full;
           default = sqlit;
         };
+
+        lib = { inherit makeSqlit; };
 
         apps.default = {
           type = "app";


### PR DESCRIPTION
Supersedes #126 and fixes #154. Current `flake.nix` on main ships zero DB drivers — a Nix install only works for SQLite files, because there's no pipx-style post-install inject on Nix. Two separate users have reported this (#126, #154).

This:

- Adds a `makeSqlit` helper with an `extras` list that mirrors the names in `pyproject.toml`'s `project.optional-dependencies`, limited to drivers nixpkgs actually packages.
- Default `sqlit` now pulls in every such extra (ssh, postgres, cockroachdb, mysql, duckdb, bigquery, snowflake, d1) so `nix run` works out of the box.
- Exposes `lib.makeSqlit` so custom flakes can opt into a different subset: `makeSqlit { extras = [ "postgres" ]; }`.
- Drivers not in nixpkgs (mssql-python, oracledb, mariadb, ibm_db, hdbcli, teradatasql, trino, presto-python-client, redshift-connector, clickhouse-connect, libsql, firebirdsql, pyathena, adbc-driver-flightsql) are noted in a single flake comment rather than as 14 no-op flags.

I don't have Nix locally — would appreciate a `nix flake check` on a Nix host before merging.