### PR TITLE
Fix D1 adapter hitting wrong endpoint (/execute -> /query)

### DIFF
--- a/sqlit/domains/connections/providers/d1/adapter.py
+++ b/sqlit/domains/connections/providers/d1/adapter.py
@@ -125,8 +125,8 @@ class D1Adapter(DatabaseAdapter):
         return [db["name"] for db in databases if "name" in db]
 
     def _execute(self, conn: D1Connection, query: str) -> dict[str, Any]:
-        """Internal method to run a command on the D1 execute endpoint."""
-        api_url = f"{self._api_base_url()}/client/v4/accounts/{conn.account_id}/d1/database/{conn.database_id}/execute"
+        """Internal method to run a command on the D1 query endpoint."""
+        api_url = f"{self._api_base_url()}/client/v4/accounts/{conn.account_id}/d1/database/{conn.database_id}/query"
         response = conn.session.post(api_url, json={"sql": query})
         response.raise_for_status()
         # The result is a list containing a single result object

--- a/tests/fixtures/d1.py
+++ b/tests/fixtures/d1.py
@@ -63,7 +63,7 @@ class _D1Client:
     def execute(self, db_name: str, sql: str) -> dict | None:
         payload = self._request(
             "POST",
-            f"/client/v4/accounts/{self._account_id}/d1/database/{db_name}/execute",
+            f"/client/v4/accounts/{self._account_id}/d1/database/{db_name}/query",
             {"sql": sql},
         )
         if not payload.get("success", False):

--- a/tests/fixtures/d1/index.js
+++ b/tests/fixtures/d1/index.js
@@ -14,7 +14,7 @@ export default {
     }
 
     const execMatch = path.match(
-      /^\/client\/v4\/accounts\/([^/]+)\/d1\/database\/([^/]+)\/execute$/
+      /^\/client\/v4\/accounts\/([^/]+)\/d1\/database\/([^/]+)\/query$/
     );
     if (execMatch && request.method === "POST") {
       let body;


### PR DESCRIPTION
Fixes #159.

The D1 adapter was posting to `/d1/database/{id}/execute`, but Cloudflare's REST API only documents `/query` and `/raw` — hence the 404 Jegor reported.

The integration test in `tests/test_d1.py` was passing despite the bug because the miniflare mock worker was written to match the broken path. Fixed the mock and the test-setup client too, so the integration test now exercises the real Cloudflare endpoint.

Verified by running `tests/test_d1.py` against miniflare (24 passed, 3 skipped).