### PR TITLE
Add vim motions to the results view

### DIFF
--- a/sqlit/core/keymap.py
+++ b/sqlit/core/keymap.py
@@ -292,6 +292,8 @@ class DefaultKeymapProvider(KeymapProvider):
             # rye results export menu
             LeaderCommandDef("c", "csv", "Export as CSV", "Export", menu="rye"),
             LeaderCommandDef("j", "json", "Export as JSON", "Export", menu="rye"),
+            # rg results g motion menu (vim-style gg)
+            LeaderCommandDef("g", "first_row", "Go to first row", "Go to", menu="rg"),
             # vy value view yank menu (tree mode)
             LeaderCommandDef("y", "value", "Copy value", "Copy", menu="vy"),
             LeaderCommandDef("f", "field", "Copy field", "Copy", menu="vy"),
@@ -447,6 +449,14 @@ class DefaultKeymapProvider(KeymapProvider):
             ActionKeyDef("j", "results_cursor_down", "results"),
             ActionKeyDef("k", "results_cursor_up", "results"),
             ActionKeyDef("l", "results_cursor_right", "results"),
+            ActionKeyDef("g", "rg_leader_key", "results"),
+            ActionKeyDef("G", "results_cursor_last_row", "results"),
+            ActionKeyDef("ctrl+u", "results_page_up", "results"),
+            ActionKeyDef("ctrl+d", "results_page_down", "results"),
+            ActionKeyDef("0", "results_cursor_first_column", "results"),
+            ActionKeyDef("dollar_sign", "results_cursor_last_column", "results"),
+            ActionKeyDef("f", "results_column_picker", "results"),
+            ActionKeyDef("F", "results_column_picker", "results", primary=False),
             ActionKeyDef("tab", "next_result_section", "results"),
             ActionKeyDef("shift+tab", "prev_result_section", "results"),
             ActionKeyDef("z", "toggle_result_section", "results"),

--- a/sqlit/domains/results/state/results_focused.py
+++ b/sqlit/domains/results/state/results_focused.py
@@ -26,6 +26,14 @@ class ResultsFocusedState(State):
         self.allows("results_cursor_down", has_results)  # vim j
         self.allows("results_cursor_up", has_results)  # vim k
         self.allows("results_cursor_right", has_results)  # vim l
+        self.allows("rg_leader_key", has_results)  # vim gg (first step)
+        self.allows("rg_first_row", has_results)  # vim gg (second step)
+        self.allows("results_cursor_last_row", has_results)  # vim G
+        self.allows("results_page_up", has_results)  # vim Ctrl+U
+        self.allows("results_page_down", has_results)  # vim Ctrl+D
+        self.allows("results_cursor_first_column", has_results)  # vim 0
+        self.allows("results_cursor_last_column", has_results)  # vim $
+        self.allows("results_column_picker", has_results)  # vim f/F
         self.allows("next_result_section", has_results, label="Next result", help="Next result section")
         self.allows("prev_result_section", has_results, label="Prev result", help="Previous result section")
 

--- a/sqlit/domains/results/ui/mixins/results.py
+++ b/sqlit/domains/results/ui/mixins/results.py
@@ -685,30 +685,57 @@ class ResultsMixin:
         """Show the results g motion leader menu (first press of gg)."""
         self._start_leader_pending("rg")
 
-    def action_rg_first_row(self: ResultsMixinHost) -> None:
-        """Jump to the first row of the results table (vim gg)."""
-        self._clear_leader_pending()
+    def _move_results_cursor_row(self: ResultsMixinHost, target_row: int) -> None:
+        """Set the results cursor to target_row, keeping the current column."""
+        from textual.coordinate import Coordinate
+
         table, _columns, _rows, _stacked = self._get_active_results_context()
-        if table and table.row_count > 0:
-            table.action_cursor_table_start()
+        if not table or table.row_count <= 0:
+            return
+        try:
+            current_col = table.cursor_coordinate.column
+        except Exception:
+            current_col = 0
+        target_row = max(0, min(target_row, table.row_count - 1))
+        try:
+            table.cursor_coordinate = Coordinate(row=target_row, column=current_col)
+        except Exception:
+            pass
+
+    def action_rg_first_row(self: ResultsMixinHost) -> None:
+        """Jump to the first row (vim gg). Column is preserved."""
+        self._clear_leader_pending()
+        self._move_results_cursor_row(0)
 
     def action_results_cursor_last_row(self: ResultsMixinHost) -> None:
-        """Jump to the last row of the results table (vim G)."""
+        """Jump to the last row (vim G). Column is preserved."""
         table, _columns, _rows, _stacked = self._get_active_results_context()
         if table and table.row_count > 0:
-            table.action_cursor_table_end()
+            self._move_results_cursor_row(table.row_count - 1)
 
     def action_results_page_up(self: ResultsMixinHost) -> None:
-        """Scroll results up one page (vim Ctrl+U)."""
+        """Scroll results up one page (vim Ctrl+U). Column is preserved."""
         table, _columns, _rows, _stacked = self._get_active_results_context()
-        if table and table.row_count > 0:
-            table.action_page_up()
+        if not table or table.row_count <= 0:
+            return
+        try:
+            current_row = table.cursor_coordinate.row
+        except Exception:
+            current_row = 0
+        page = max(1, table.size.height - 1)
+        self._move_results_cursor_row(current_row - page)
 
     def action_results_page_down(self: ResultsMixinHost) -> None:
-        """Scroll results down one page (vim Ctrl+D)."""
+        """Scroll results down one page (vim Ctrl+D). Column is preserved."""
         table, _columns, _rows, _stacked = self._get_active_results_context()
-        if table and table.row_count > 0:
-            table.action_page_down()
+        if not table or table.row_count <= 0:
+            return
+        try:
+            current_row = table.cursor_coordinate.row
+        except Exception:
+            current_row = 0
+        page = max(1, table.size.height - 1)
+        self._move_results_cursor_row(current_row + page)
 
     def action_results_cursor_first_column(self: ResultsMixinHost) -> None:
         """Move cursor to the first column of the current row (vim 0)."""

--- a/sqlit/domains/results/ui/mixins/results.py
+++ b/sqlit/domains/results/ui/mixins/results.py
@@ -681,6 +681,72 @@ class ResultsMixin:
         if table and table.has_focus:
             table.action_cursor_right()
 
+    def action_rg_leader_key(self: ResultsMixinHost) -> None:
+        """Show the results g motion leader menu (first press of gg)."""
+        self._start_leader_pending("rg")
+
+    def action_rg_first_row(self: ResultsMixinHost) -> None:
+        """Jump to the first row of the results table (vim gg)."""
+        self._clear_leader_pending()
+        table, _columns, _rows, _stacked = self._get_active_results_context()
+        if table and table.row_count > 0:
+            table.action_cursor_table_start()
+
+    def action_results_cursor_last_row(self: ResultsMixinHost) -> None:
+        """Jump to the last row of the results table (vim G)."""
+        table, _columns, _rows, _stacked = self._get_active_results_context()
+        if table and table.row_count > 0:
+            table.action_cursor_table_end()
+
+    def action_results_page_up(self: ResultsMixinHost) -> None:
+        """Scroll results up one page (vim Ctrl+U)."""
+        table, _columns, _rows, _stacked = self._get_active_results_context()
+        if table and table.row_count > 0:
+            table.action_page_up()
+
+    def action_results_page_down(self: ResultsMixinHost) -> None:
+        """Scroll results down one page (vim Ctrl+D)."""
+        table, _columns, _rows, _stacked = self._get_active_results_context()
+        if table and table.row_count > 0:
+            table.action_page_down()
+
+    def action_results_cursor_first_column(self: ResultsMixinHost) -> None:
+        """Move cursor to the first column of the current row (vim 0)."""
+        table, _columns, _rows, _stacked = self._get_active_results_context()
+        if table and table.row_count > 0:
+            table.action_cursor_row_start()
+
+    def action_results_cursor_last_column(self: ResultsMixinHost) -> None:
+        """Move cursor to the last column of the current row (vim $)."""
+        table, _columns, _rows, _stacked = self._get_active_results_context()
+        if table and table.row_count > 0:
+            table.action_cursor_row_end()
+
+    def action_results_column_picker(self: ResultsMixinHost) -> None:
+        """Open a filterable column picker; jump cursor to the selected column (vim f/F)."""
+        from textual.coordinate import Coordinate
+
+        from sqlit.domains.results.ui.screens import ColumnPickerScreen
+
+        table, columns, _rows, _stacked = self._get_active_results_context()
+        if not table or table.row_count <= 0 or not columns:
+            self.notify("No results", severity="warning")
+            return
+
+        def handle_result(column_index: int | None) -> None:
+            if column_index is None:
+                return
+            try:
+                current_row = table.cursor_coordinate.row
+            except Exception:
+                current_row = 0
+            try:
+                table.cursor_coordinate = Coordinate(row=current_row, column=column_index)
+            except Exception:
+                pass
+
+        self.push_screen(ColumnPickerScreen(list(columns)), handle_result)
+
     def action_clear_results(self: ResultsMixinHost) -> None:
         """Clear the results table."""
         if self.results_area.has_class("stacked-mode"):

--- a/sqlit/domains/results/ui/screens/__init__.py
+++ b/sqlit/domains/results/ui/screens/__init__.py
@@ -1,1 +1,5 @@
-"""Package."""
+"""Results screens."""
+
+from .column_picker import ColumnPickerScreen
+
+__all__ = ["ColumnPickerScreen"]

--- a/sqlit/domains/results/ui/screens/column_picker.py
+++ b/sqlit/domains/results/ui/screens/column_picker.py
@@ -1,0 +1,149 @@
+"""Filterable column picker for jumping the results cursor to a specific column."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Input, OptionList
+from textual.widgets.option_list import Option
+
+from sqlit.shared.ui.widgets import Dialog
+
+
+class ColumnPickerScreen(ModalScreen[int | None]):
+    """Modal dialog that lets the user fuzzy-filter columns and pick one.
+
+    Dismisses with the index of the chosen column (into the original list
+    supplied at construction time), or `None` if cancelled.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel", show=False),
+        Binding("enter", "submit", "Jump", show=False),
+        Binding("down", "cursor_down", "Next", show=False),
+        Binding("up", "cursor_up", "Previous", show=False),
+        Binding("ctrl+j", "cursor_down", "Next", show=False),
+        Binding("ctrl+k", "cursor_up", "Previous", show=False),
+    ]
+
+    CSS = """
+    ColumnPickerScreen {
+        align: center middle;
+        background: transparent;
+    }
+
+    #column-picker-dialog {
+        width: 50;
+        max-width: 80%;
+        height: auto;
+        max-height: 22;
+    }
+
+    #column-picker-body {
+        height: auto;
+        max-height: 20;
+    }
+
+    #column-picker-input {
+        height: 3;
+        border: solid $panel;
+        background: $surface;
+    }
+
+    #column-picker-input:focus {
+        border: solid $primary;
+    }
+
+    #column-picker-list {
+        height: auto;
+        max-height: 14;
+        border: none;
+        background: $surface;
+    }
+    """
+
+    def __init__(self, columns: list[str]) -> None:
+        super().__init__()
+        self._columns = columns
+        self._filtered: list[tuple[int, str]] = list(enumerate(columns))
+
+    def compose(self) -> ComposeResult:
+        shortcuts: list[tuple[str, str]] = [("Jump", "<enter>"), ("Cancel", "<esc>")]
+        with Dialog(id="column-picker-dialog", title="Jump to column", shortcuts=shortcuts):
+            with Vertical(id="column-picker-body"):
+                yield Input(placeholder="Filter...", id="column-picker-input")
+                yield OptionList(*self._render_options(), id="column-picker-list")
+
+    def on_mount(self) -> None:
+        self.query_one("#column-picker-input", Input).focus()
+
+    def _render_options(self) -> list[Option]:
+        return [Option(name, id=str(idx)) for idx, name in self._filtered]
+
+    def _rebuild_options(self, query: str) -> None:
+        needle = query.strip().lower()
+        if needle:
+            self._filtered = [
+                (idx, name) for idx, name in enumerate(self._columns) if needle in name.lower()
+            ]
+        else:
+            self._filtered = list(enumerate(self._columns))
+        option_list = self.query_one("#column-picker-list", OptionList)
+        option_list.clear_options()
+        for option in self._render_options():
+            option_list.add_option(option)
+        if self._filtered:
+            option_list.highlighted = 0
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "column-picker-input":
+            self._rebuild_options(event.value)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "column-picker-input":
+            self._submit_highlighted()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        option_id = event.option.id
+        if option_id is not None:
+            try:
+                self.dismiss(int(option_id))
+                return
+            except ValueError:
+                pass
+        self.dismiss(None)
+
+    def action_cursor_down(self) -> None:
+        option_list = self.query_one("#column-picker-list", OptionList)
+        if option_list.option_count:
+            option_list.action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        option_list = self.query_one("#column-picker-list", OptionList)
+        if option_list.option_count:
+            option_list.action_cursor_up()
+
+    def action_submit(self) -> None:
+        self._submit_highlighted()
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def _submit_highlighted(self) -> None:
+        option_list = self.query_one("#column-picker-list", OptionList)
+        if not self._filtered:
+            self.dismiss(None)
+            return
+        highlighted = option_list.highlighted if option_list.highlighted is not None else 0
+        highlighted = max(0, min(highlighted, len(self._filtered) - 1))
+        idx, _name = self._filtered[highlighted]
+        self.dismiss(idx)
+
+    def check_action(self, action: str, parameters: Any) -> bool | None:
+        if self.app.screen is not self:
+            return False
+        return super().check_action(action, parameters)

--- a/tests/ui/keybindings/test_results_vim_motions.py
+++ b/tests/ui/keybindings/test_results_vim_motions.py
@@ -41,29 +41,37 @@ class TestResultsVimMotions:
     """Vim motions bound to the results view."""
 
     @pytest.mark.asyncio
-    async def test_G_jumps_to_last_row(self) -> None:
+    async def test_G_jumps_to_last_row_preserving_column(self) -> None:
         app = _make_app()
         async with app.run_test(size=(100, 35)) as pilot:
-            columns = ["id", "name"]
-            rows = [(i, f"row-{i}") for i in range(20)]
+            columns = ["id", "name", "email"]
+            rows = [(i, f"row-{i}", f"e{i}@x") for i in range(20)]
             await _populate_results(pilot, app, columns, rows)
             await pilot.pause()
 
-            assert app.results_table.cursor_coordinate.row == 0
+            # Move to column 2 first, then jump to end.
+            await pilot.press("l", "l")
+            await pilot.pause()
+            assert app.results_table.cursor_coordinate.column == 2
 
             await pilot.press("G")
             await pilot.pause()
 
             assert app.results_table.cursor_coordinate.row == len(rows) - 1
+            assert app.results_table.cursor_coordinate.column == 2
 
     @pytest.mark.asyncio
-    async def test_gg_jumps_to_first_row(self) -> None:
+    async def test_gg_jumps_to_first_row_preserving_column(self) -> None:
         app = _make_app()
         async with app.run_test(size=(100, 35)) as pilot:
-            columns = ["id", "name"]
-            rows = [(i, f"row-{i}") for i in range(20)]
+            columns = ["id", "name", "email"]
+            rows = [(i, f"row-{i}", f"e{i}@x") for i in range(20)]
             await _populate_results(pilot, app, columns, rows)
             await pilot.pause()
+
+            await pilot.press("l", "l")
+            await pilot.pause()
+            assert app.results_table.cursor_coordinate.column == 2
 
             await pilot.press("G")
             await pilot.pause()
@@ -74,27 +82,33 @@ class TestResultsVimMotions:
             await pilot.pause()
 
             assert app.results_table.cursor_coordinate.row == 0
+            assert app.results_table.cursor_coordinate.column == 2
 
     @pytest.mark.asyncio
-    async def test_ctrl_d_and_ctrl_u_page(self) -> None:
+    async def test_ctrl_d_and_ctrl_u_page_preserve_column(self) -> None:
         app = _make_app()
         async with app.run_test(size=(100, 20)) as pilot:
-            columns = ["id"]
-            rows = [(i,) for i in range(200)]
+            columns = ["id", "a", "b"]
+            rows = [(i, i * 2, i * 3) for i in range(200)]
             await _populate_results(pilot, app, columns, rows)
             await pilot.pause()
 
+            await pilot.press("l")
+            await pilot.pause()
+            assert app.results_table.cursor_coordinate.column == 1
             start_row = app.results_table.cursor_coordinate.row
 
             await pilot.press("ctrl+d")
             await pilot.pause()
             after_page_down = app.results_table.cursor_coordinate.row
             assert after_page_down > start_row, "ctrl+d should move cursor down by a page"
+            assert app.results_table.cursor_coordinate.column == 1
 
             await pilot.press("ctrl+u")
             await pilot.pause()
             after_page_up = app.results_table.cursor_coordinate.row
             assert after_page_up < after_page_down, "ctrl+u should move cursor up again"
+            assert app.results_table.cursor_coordinate.column == 1
 
     @pytest.mark.asyncio
     async def test_0_and_dollar_move_within_row(self) -> None:

--- a/tests/ui/keybindings/test_results_vim_motions.py
+++ b/tests/ui/keybindings/test_results_vim_motions.py
@@ -1,0 +1,185 @@
+"""UI tests for vim motion keybindings in the results table (issue #170)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sqlit.domains.shell.app.main import SSMSTUI
+
+from ..mocks import MockConnectionStore, MockSettingsStore, build_test_services
+
+
+def _make_app() -> SSMSTUI:
+    services = build_test_services(
+        connection_store=MockConnectionStore(),
+        settings_store=MockSettingsStore({"theme": "tokyo-night"}),
+    )
+    return SSMSTUI(services=services)
+
+
+async def _populate_results(pilot: Any, app: SSMSTUI, columns: list[str], rows: list[tuple]) -> None:
+    """Display a set of results on the app and focus the results table."""
+    # Wait for the Lazy-loaded results table to exist.
+    await pilot.pause()
+    await app._display_query_results(
+        columns=columns,
+        rows=rows,
+        row_count=len(rows),
+        truncated=False,
+        elapsed_ms=0,
+    )
+    # Let any incremental render timers run.
+    for _ in range(3):
+        await pilot.pause(0.05)
+    app.action_focus_results()
+    await pilot.pause()
+
+
+class TestResultsVimMotions:
+    """Vim motions bound to the results view."""
+
+    @pytest.mark.asyncio
+    async def test_G_jumps_to_last_row(self) -> None:
+        app = _make_app()
+        async with app.run_test(size=(100, 35)) as pilot:
+            columns = ["id", "name"]
+            rows = [(i, f"row-{i}") for i in range(20)]
+            await _populate_results(pilot, app, columns, rows)
+            await pilot.pause()
+
+            assert app.results_table.cursor_coordinate.row == 0
+
+            await pilot.press("G")
+            await pilot.pause()
+
+            assert app.results_table.cursor_coordinate.row == len(rows) - 1
+
+    @pytest.mark.asyncio
+    async def test_gg_jumps_to_first_row(self) -> None:
+        app = _make_app()
+        async with app.run_test(size=(100, 35)) as pilot:
+            columns = ["id", "name"]
+            rows = [(i, f"row-{i}") for i in range(20)]
+            await _populate_results(pilot, app, columns, rows)
+            await pilot.pause()
+
+            await pilot.press("G")
+            await pilot.pause()
+            assert app.results_table.cursor_coordinate.row == len(rows) - 1
+
+            await pilot.press("g")
+            await pilot.press("g")
+            await pilot.pause()
+
+            assert app.results_table.cursor_coordinate.row == 0
+
+    @pytest.mark.asyncio
+    async def test_ctrl_d_and_ctrl_u_page(self) -> None:
+        app = _make_app()
+        async with app.run_test(size=(100, 20)) as pilot:
+            columns = ["id"]
+            rows = [(i,) for i in range(200)]
+            await _populate_results(pilot, app, columns, rows)
+            await pilot.pause()
+
+            start_row = app.results_table.cursor_coordinate.row
+
+            await pilot.press("ctrl+d")
+            await pilot.pause()
+            after_page_down = app.results_table.cursor_coordinate.row
+            assert after_page_down > start_row, "ctrl+d should move cursor down by a page"
+
+            await pilot.press("ctrl+u")
+            await pilot.pause()
+            after_page_up = app.results_table.cursor_coordinate.row
+            assert after_page_up < after_page_down, "ctrl+u should move cursor up again"
+
+    @pytest.mark.asyncio
+    async def test_0_and_dollar_move_within_row(self) -> None:
+        app = _make_app()
+        async with app.run_test(size=(120, 35)) as pilot:
+            columns = ["a", "b", "c", "d", "e"]
+            rows = [(1, 2, 3, 4, 5), (6, 7, 8, 9, 10)]
+            await _populate_results(pilot, app, columns, rows)
+            await pilot.pause()
+
+            await pilot.press("l")
+            await pilot.press("l")
+            await pilot.pause()
+            assert app.results_table.cursor_coordinate.column == 2
+
+            await pilot.press("dollar_sign")
+            await pilot.pause()
+            assert app.results_table.cursor_coordinate.column == len(columns) - 1
+
+            await pilot.press("0")
+            await pilot.pause()
+            assert app.results_table.cursor_coordinate.column == 0
+
+    @pytest.mark.asyncio
+    async def test_f_opens_column_picker_and_jumps(self) -> None:
+        from sqlit.domains.results.ui.screens import ColumnPickerScreen
+
+        app = _make_app()
+        async with app.run_test(size=(100, 35)) as pilot:
+            columns = ["id", "first_name", "last_name", "email", "created_at"]
+            rows = [(i, f"first{i}", f"last{i}", f"e{i}@x", f"2024-0{i}") for i in range(3)]
+            await _populate_results(pilot, app, columns, rows)
+            await pilot.pause()
+
+            assert app.results_table.cursor_coordinate.column == 0
+
+            await pilot.press("f")
+            await pilot.pause()
+
+            assert isinstance(app.screen, ColumnPickerScreen)
+
+            await pilot.press("e", "m", "a", "i")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert app.results_table.cursor_coordinate.column == columns.index("email")
+
+    @pytest.mark.asyncio
+    async def test_F_also_opens_column_picker(self) -> None:
+        from sqlit.domains.results.ui.screens import ColumnPickerScreen
+
+        app = _make_app()
+        async with app.run_test(size=(100, 35)) as pilot:
+            columns = ["id", "name"]
+            rows = [(1, "a"), (2, "b")]
+            await _populate_results(pilot, app, columns, rows)
+            await pilot.pause()
+
+            await pilot.press("F")
+            await pilot.pause()
+
+            assert isinstance(app.screen, ColumnPickerScreen)
+
+    @pytest.mark.asyncio
+    async def test_column_picker_escape_cancels(self) -> None:
+        from sqlit.domains.results.ui.screens import ColumnPickerScreen
+
+        app = _make_app()
+        async with app.run_test(size=(100, 35)) as pilot:
+            columns = ["id", "name"]
+            rows = [(1, "a"), (2, "b")]
+            await _populate_results(pilot, app, columns, rows)
+            await pilot.pause()
+
+            await pilot.press("l")
+            await pilot.pause()
+            assert app.results_table.cursor_coordinate.column == 1
+
+            await pilot.press("f")
+            await pilot.pause()
+            assert isinstance(app.screen, ColumnPickerScreen)
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert not isinstance(app.screen, ColumnPickerScreen)
+            assert app.results_table.cursor_coordinate.column == 1


### PR DESCRIPTION
Closes #170.

Adds vim-style navigation to the results table:

- `gg` / `G` — first / last row
- `Ctrl+U` / `Ctrl+D` — page up / down
- `0` / `$` — first / last column of the current row
- `f` / `F` — filterable column picker; typing narrows the list, `Enter` jumps the cursor to that column, `Esc` cancels

`gg` reuses the existing leader-menu pattern (new `rg` menu, mirroring how `g` works in the query editor). The other motions delegate to `FastDataTable`'s own `action_cursor_*` / `action_page_*` methods, so scroll-follow, wrapping, and empty-table behavior come for free.

Tests in `tests/ui/keybindings/test_results_vim_motions.py` drive the app with Textual's pilot, populate results via `_display_query_results`, and assert `cursor_coordinate` after each key press.