### PR TITLE
Fix HANA get_columns on HANA Cloud (#153)

### DIFF
--- a/sqlit/domains/connections/providers/hana/adapter.py
+++ b/sqlit/domains/connections/providers/hana/adapter.py
@@ -115,19 +115,15 @@ class HanaAdapter(CursorBasedAdapter):
         schema = schema or self.default_schema
 
         cursor.execute(
-            "SELECT cc.column_name "
-            "FROM sys.constraints c "
-            "JOIN sys.constraint_columns cc "
-            "  ON c.schema_name = cc.schema_name "
-            " AND c.constraint_name = cc.constraint_name "
-            "WHERE c.constraint_type = 'PRIMARY KEY' "
-            "AND c.schema_name = ? AND c.table_name = ?",
+            "SELECT column_name FROM sys.constraints "
+            "WHERE is_primary_key = 'TRUE' "
+            "AND schema_name = ? AND table_name = ?",
             (schema, table),
         )
         pk_columns = {row[0] for row in cursor.fetchall()}
 
         cursor.execute(
-            "SELECT column_name, data_type_name FROM sys.columns "
+            "SELECT column_name, data_type_name FROM sys.table_columns "
             "WHERE schema_name = ? AND table_name = ? "
             "ORDER BY position",
             (schema, table),

--- a/tests/connections/providers/hana/test_get_columns.py
+++ b/tests/connections/providers/hana/test_get_columns.py
@@ -1,0 +1,95 @@
+"""Tests for HANA adapter column discovery.
+
+Regression coverage for #153: SYS.CONSTRAINT_COLUMNS and SYS.COLUMNS
+are not queryable in current HANA Cloud schemas. get_columns must use
+SYS.CONSTRAINTS (which already exposes COLUMN_NAME and IS_PRIMARY_KEY
+per column) and SYS.TABLE_COLUMNS.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sqlit.domains.connections.providers.adapters.base import ColumnInfo
+from sqlit.domains.connections.providers.hana.adapter import HanaAdapter
+
+
+@pytest.fixture
+def adapter() -> HanaAdapter:
+    return HanaAdapter()
+
+
+@pytest.fixture
+def mock_conn() -> MagicMock:
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchall.return_value = []
+    conn.cursor.return_value = cursor
+    return conn
+
+
+def _executed_sql(mock_conn: MagicMock) -> list[str]:
+    return [call.args[0].lower() for call in mock_conn.cursor.return_value.execute.call_args_list]
+
+
+def test_get_columns_does_not_use_deprecated_or_missing_views(
+    adapter: HanaAdapter, mock_conn: MagicMock
+) -> None:
+    adapter.get_columns(mock_conn, "MY_TABLE", schema="MY_SCHEMA")
+
+    sqls = _executed_sql(mock_conn)
+    joined = " | ".join(sqls)
+    assert "sys.constraint_columns" not in joined
+    assert "from sys.columns" not in joined
+    assert "sys.table_columns" in joined
+
+
+def test_get_columns_filters_primary_key_on_constraints_view(
+    adapter: HanaAdapter, mock_conn: MagicMock
+) -> None:
+    adapter.get_columns(mock_conn, "MY_TABLE", schema="MY_SCHEMA")
+
+    sqls = _executed_sql(mock_conn)
+    pk_query = next(sql for sql in sqls if "sys.constraints" in sql)
+    assert "is_primary_key" in pk_query
+    assert "column_name" in pk_query
+
+
+def test_get_columns_passes_schema_and_table_as_parameters(
+    adapter: HanaAdapter, mock_conn: MagicMock
+) -> None:
+    adapter.get_columns(mock_conn, "MY_TABLE", schema="MY_SCHEMA")
+
+    calls = mock_conn.cursor.return_value.execute.call_args_list
+    assert len(calls) == 2
+    for call in calls:
+        assert call.args[1] == ("MY_SCHEMA", "MY_TABLE")
+
+
+def test_get_columns_combines_pk_and_column_results(
+    adapter: HanaAdapter, mock_conn: MagicMock
+) -> None:
+    cursor = mock_conn.cursor.return_value
+    cursor.fetchall.side_effect = [
+        [("ID",)],
+        [("ID", "INTEGER"), ("NAME", "NVARCHAR")],
+    ]
+
+    result = adapter.get_columns(mock_conn, "MY_TABLE", schema="MY_SCHEMA")
+
+    assert result == [
+        ColumnInfo(name="ID", data_type="INTEGER", is_primary_key=True),
+        ColumnInfo(name="NAME", data_type="NVARCHAR", is_primary_key=False),
+    ]
+
+
+def test_get_columns_defaults_schema_when_not_provided(
+    adapter: HanaAdapter, mock_conn: MagicMock
+) -> None:
+    adapter.get_columns(mock_conn, "MY_TABLE")
+
+    calls = mock_conn.cursor.return_value.execute.call_args_list
+    for call in calls:
+        assert call.args[1] == (adapter.default_schema, "MY_TABLE")


### PR DESCRIPTION
Fixes #153.

HANA Cloud's `SYS.CONSTRAINT_COLUMNS` doesn't exist, and `SYS.COLUMNS` has been deprecated since HANA 2 SP03. `SYS.CONSTRAINTS` already has `COLUMN_NAME` and `IS_PRIMARY_KEY` per column, so we can drop the join and read columns from `SYS.TABLE_COLUMNS` instead.

Added mocked unit tests for `get_columns` so we'd catch a regression — there are no HANA integration tests yet (SAP doesn't ship a Docker image, so the usual compose setup doesn't cover it).