### PR TITLE
🚀 feat(query-history): append history queries without replacing

### DIFF
--- a/sqlit/domains/query/ui/mixins/query_execution.py
+++ b/sqlit/domains/query/ui/mixins/query_execution.py
@@ -754,6 +754,28 @@ class QueryExecutionMixin(ProcessWorkerLifecycleMixin):
         # Focus query input - this triggers on_descendant_focus which updates footer bindings
         self.query_input.focus()
 
+    def _append_history_query(self: QueryMixinHost, query: str) -> None:
+        """Append a query to the end of the editor without replacing text."""
+        if query is None:
+            return
+
+        current_text = self.query_input.text
+        if current_text:
+            trimmed_current = current_text.rstrip("\n")
+            separator = "\n" if trimmed_current else ""
+            new_text = f"{trimmed_current}{separator}{query}"
+        else:
+            new_text = query
+
+        self._push_undo_state()
+        self.query_input.text = new_text
+
+        lines = new_text.split("\n")
+        last_line = len(lines) - 1
+        last_col = len(lines[-1]) if lines else 0
+        self.query_input.cursor_location = (last_line, last_col)
+        self.query_input.focus()
+
     def action_show_history(self: QueryMixinHost) -> None:
         """Show query history for the current connection."""
         if not self.current_config:
@@ -781,6 +803,8 @@ class QueryExecutionMixin(ProcessWorkerLifecycleMixin):
         action, data = result
         if action == "select":
             self._apply_history_query(data)
+        elif action == "append":
+            self._append_history_query(data)
         elif action == "delete":
             self._delete_history_entry(data)
             self.action_show_history()
@@ -853,6 +877,10 @@ class QueryExecutionMixin(ProcessWorkerLifecycleMixin):
             connection_name = data.get("connection_name", "")
             database = data.get("database", "")
             self._run_telescope_query(connection_name, query, database=database)
+        elif action == "append":
+            query = data.get("query", "")
+            if query:
+                self._append_history_query(query)
         elif action == "delete":
             timestamp = data.get("timestamp", "")
             connection_name = data.get("connection_name", "")

--- a/sqlit/domains/query/ui/screens/query_history.py
+++ b/sqlit/domains/query/ui/screens/query_history.py
@@ -26,6 +26,7 @@ class QueryHistoryScreen(ModalScreen):
         Binding("escape", "cancel", "Cancel", priority=True),
         Binding("q", "cancel", "Cancel"),
         Binding("enter", "select", "Select"),
+        Binding("a", "append", "Append"),
         Binding("d", "delete", "Delete"),
         Binding("asterisk", "toggle_star", "Star"),
         Binding("slash", "open_filter", "Filter"),
@@ -177,7 +178,12 @@ class QueryHistoryScreen(ModalScreen):
         else:
             title = f"Query History - {self.connection_name}"
             empty_message = "No query history for this connection"
-        shortcuts = [("Select", "<enter>"), ("Star", "*"), ("Delete", "D")]
+        shortcuts = [
+            ("Select", "<enter>"),
+            ("Append", "a"),
+            ("Star", "*"),
+            ("Delete", "D"),
+        ]
 
         self._merged_entries = self._merge_entries()
 
@@ -235,6 +241,22 @@ class QueryHistoryScreen(ModalScreen):
             idx = option_list.highlighted
             if idx is not None and idx < len(entries):
                 self.dismiss(self._build_action_result("select", entries[idx]))
+            else:
+                self.dismiss(None)
+        except Exception:
+            self.dismiss(None)
+
+    def action_append(self) -> None:
+        entries = self._get_display_entries()
+        if not entries:
+            self.dismiss(None)
+            return
+
+        try:
+            option_list = self.query_one("#history-list", OptionList)
+            idx = option_list.highlighted
+            if idx is not None and idx < len(entries):
+                self.dismiss(self._build_action_result("append", entries[idx]))
             else:
                 self.dismiss(None)
         except Exception:


### PR DESCRIPTION
## Summary
This PR adds the ability to **append a query from history to the editor without replacing the current text**. Previously, selecting a query from history (via `QueryHistoryScreen` or Telescope) would overwrite whatever was in the editor. Now users can press `a` to append the selected query instead.
## Motivation
When working with query history, it's common to want to reuse or combine previous queries. The existing behavior (`<enter>`) replaces the entire editor content, which is destructive if you're building a multi-statement query or referencing previous snippets. Appending provides a non-destructive alternative.
## Changes
### 1. New `_append_history_query()` method
Added to `QueryExecutionMixin` (`sqlit/domains/query/ui/mixins/query_execution.py`):
- Appends the selected query to the end of the current editor text
- Adds a newline separator if the editor is not empty
- Preserves undo state via `_push_undo_state()`
- Moves cursor to the end of the appended text
- Focuses the query input
### 2. New `append` action in `QueryHistoryScreen`
Added to `sqlit/domains/query/ui/screens/query_history.py`:
- New key binding: **`a`** → `action_append`
- Updated footer shortcuts to show `Append (a)` alongside existing actions
- Returns `("append", entry)` result to the caller
### 3. Handle `append` action in result handlers
Updated both `_handle_history_result` and `_handle_telescope_result` in `QueryExecutionMixin` to handle the new `"append"` action and delegate to `_append_history_query()`.
## How to test
1. Open **Query History** (`H`) or **Telescope** (`Ctrl+T`)
2. Write some text in the query editor (or leave it empty)
3. Navigate to a history entry and press **`a`**
4. The query should appear appended at the end of the editor, with proper newline separation
## Keymap
| Key | Action |
|-----|--------|
| `<enter>` | Select (replaces editor content) |
| `a` | **Append** (adds to editor content) |
| `*` | Toggle star |
| `d` | Delete entry |