### PR TITLE
Feat/mode append

### DIFF
--- a/sqlit/domains/explorer/ui/mixins/tree.py
+++ b/sqlit/domains/explorer/ui/mixins/tree.py
@@ -22,6 +22,9 @@ if TYPE_CHECKING:
     from sqlit.domains.connections.providers.model import DatabaseProvider
 
 MIN_TIMER_DELAY_S = 0.001
+SELECT_TABLE_MODE_REPLACE = "replace"
+SELECT_TABLE_MODE_APPEND = "append"
+_VALID_SELECT_TABLE_MODES = {SELECT_TABLE_MODE_REPLACE, SELECT_TABLE_MODE_APPEND}
 
 
 class TreeMixin(TreeSchemaMixin, TreeLabelMixin):
@@ -39,6 +42,41 @@ class TreeMixin(TreeSchemaMixin, TreeLabelMixin):
     _expanded_state_save_timer: Any | None = None
     _schema_service: Any | None = None
     _schema_service_session: Any | None = None
+
+    def _get_select_table_mode(self: TreeMixinHost) -> str:
+        services = getattr(self, "services", None)
+        settings_store = getattr(services, "settings_store", None)
+        if settings_store is None:
+            return SELECT_TABLE_MODE_REPLACE
+        raw_mode = settings_store.get("select_table_mode", SELECT_TABLE_MODE_REPLACE)
+        mode = str(raw_mode).strip().lower() if raw_mode is not None else SELECT_TABLE_MODE_REPLACE
+        if mode not in _VALID_SELECT_TABLE_MODES:
+            return SELECT_TABLE_MODE_REPLACE
+        return mode
+
+    def _append_generated_query(self: TreeMixinHost, generated_query: str) -> None:
+        current_text = self.query_input.text
+        stripped_current = current_text.rstrip()
+        if not stripped_current:
+            next_text = generated_query
+        else:
+            next_text = f"{stripped_current}\n\n{generated_query}"
+        self.query_input.text = next_text
+        cursor_setter = getattr(self.query_input, "cursor_location", None)
+        if cursor_setter is not None:
+            try:
+                lines = next_text.splitlines() or [""]
+                self.query_input.cursor_location = (len(lines) - 1, len(lines[-1]))
+            except Exception:
+                pass
+
+    def _execute_generated_select(self: TreeMixinHost, mode: str) -> None:
+        if mode == SELECT_TABLE_MODE_APPEND:
+            execute_single = getattr(self, "action_execute_single_statement", None)
+            if callable(execute_single):
+                execute_single()
+                return
+        self.action_execute_query()
 
     def _emit_debug(self: TreeMixinHost, name: str, **data: Any) -> None:
         emit = getattr(self, "emit_debug_event", None)
@@ -335,14 +373,19 @@ class TreeMixin(TreeSchemaMixin, TreeLabelMixin):
             self._pending_result_table_info = self._last_query_table
             self._prime_last_query_table_columns(data.database, data.schema, data.name)
 
-            self.query_input.text = self.current_provider.dialect.build_select_query(
+            generated_query = self.current_provider.dialect.build_select_query(
                 data.name,
                 100,
                 data.database,
                 data.schema,
             )
+            mode = self._get_select_table_mode()
+            if mode == SELECT_TABLE_MODE_APPEND:
+                self._append_generated_query(generated_query)
+            else:
+                self.query_input.text = generated_query
             self._query_target_database = data.database
-            self.action_execute_query()
+            self._execute_generated_select(mode)
             return
 
         if self._get_node_kind(node) == "index":

--- a/sqlit/domains/shell/app/main.py
+++ b/sqlit/domains/shell/app/main.py
@@ -727,6 +727,13 @@ class SSMSTUI(
                     return
                 self._set_process_worker_auto_shutdown(seconds)
                 return
+            if target in {"select_table_mode", "select_table"}:
+                if not value:
+                    current = self.services.settings_store.get("select_table_mode", "replace")
+                    self.notify(f"select_table_mode is '{current}' (append|replace)", severity="information")
+                    return
+                self._set_select_table_mode(value)
+                return
 
         if dispatch_command(self, cmd, args):
             return
@@ -784,6 +791,7 @@ class SSMSTUI(
             ("Settings", ":set process_worker_warm on|off", "Warm worker on idle", ""),
             ("Settings", ":set process_worker_lazy on|off", "Lazy worker start", ""),
             ("Settings", ":set process_worker_auto_shutdown <seconds>", "Auto-shutdown worker", ""),
+            ("Settings", ":set select_table_mode append|replace", "Table SELECT behavior", "append adds to query, replace overwrites"),
             (
                 "Watchdog",
                 ":wd <ms|off>",
@@ -960,6 +968,22 @@ class SSMSTUI(
             pass
         state = "enabled" if enabled else "disabled"
         self.notify(f"Relative line numbers {state}")
+
+    def _set_select_table_mode(self, mode: str) -> None:
+        """Set how table SELECT queries are inserted into the query editor.
+
+        Args:
+            mode: 'append' to add below existing query, 'replace' to overwrite.
+        """
+        normalized = mode.strip().lower()
+        if normalized not in {"append", "replace"}:
+            self.notify("Usage: :set select_table_mode append|replace", severity="warning")
+            return
+        try:
+            self.services.settings_store.set("select_table_mode", normalized)
+        except Exception:
+            pass
+        self.notify(f"Select table mode set to {normalized}")
 
     def _set_process_worker_warm_on_idle(self, enabled: bool) -> None:
         self.services.runtime.process_worker_warm_on_idle = enabled

--- a/tests/ui/explorer/test_cross_database_query.py
+++ b/tests/ui/explorer/test_cross_database_query.py
@@ -73,6 +73,7 @@ class MockQueryInput:
 
     def __init__(self):
         self.text = ""
+        self.cursor_location = (0, 0)
 
 
 class TestCrossDatabaseQuery:
@@ -308,3 +309,72 @@ class TestSameDatabaseQuery:
         # Target database matches connected database - no override needed
         assert mixin._query_target_database == "norway_culture"
         assert mixin.action_execute_query.called
+
+
+class TestSelectTableMode:
+    """Tests for select_table_mode behavior."""
+
+    @staticmethod
+    def _build_mixin(*, mode: str = "replace", initial_query: str = "") -> TreeMixin:
+        mixin = object.__new__(TreeMixin)
+
+        mixin.current_provider = MagicMock()
+        mixin.current_provider.capabilities = SchemaCapabilities(
+            supports_multiple_databases=True,
+            supports_cross_database_queries=True,
+            supports_stored_procedures=False,
+            supports_indexes=False,
+            supports_triggers=False,
+            supports_sequences=False,
+            default_schema="public",
+            system_databases=frozenset(),
+        )
+        mixin.current_provider.dialect = MockDialect()
+
+        mixin._session = MagicMock()
+        mixin.current_connection = MagicMock()
+        mixin.current_config = MockConfig(database="norway_culture")
+
+        mixin.object_tree = MockTree()
+        mixin.object_tree.cursor_node = MockTreeNode(
+            label="fjords",
+            data=TableNode(database="norway_geography", schema="public", name="fjords"),
+        )
+
+        mixin.query_input = MockQueryInput()
+        mixin.query_input.text = initial_query
+        mixin._get_node_kind = lambda node: "table" if isinstance(node.data, TableNode) else ""
+        mixin._prime_last_query_table_columns = MagicMock()
+        mixin._query_target_database = None
+        mixin.action_execute_query = MagicMock()
+        mixin.action_execute_single_statement = MagicMock()
+
+        mixin.services = MagicMock()
+        mixin.services.settings_store = MagicMock()
+        mixin.services.settings_store.get = MagicMock(return_value=mode)
+        return mixin
+
+    def test_select_table_mode_replace_keeps_default_behavior(self):
+        # Arrange
+        mixin = self._build_mixin(mode="replace", initial_query="SELECT 1;")
+
+        # Act
+        mixin.action_select_table()
+
+        # Assert
+        assert mixin.query_input.text == "SELECT * FROM public.fjords LIMIT 100"
+        mixin.action_execute_query.assert_called_once_with()
+        mixin.action_execute_single_statement.assert_not_called()
+
+    def test_select_table_mode_append_adds_query_and_executes_only_last_statement(self):
+        # Arrange
+        mixin = self._build_mixin(mode="append", initial_query="SELECT 1;")
+
+        # Act
+        mixin.action_select_table()
+
+        # Assert
+        assert mixin.query_input.text == "SELECT 1;\n\nSELECT * FROM public.fjords LIMIT 100"
+        mixin.action_execute_single_statement.assert_called_once_with()
+        mixin.action_execute_query.assert_not_called()
+        assert mixin.query_input.cursor_location == (2, len("SELECT * FROM public.fjords LIMIT 100"))


### PR DESCRIPTION
## Summary
Add `append` mode for table SELECT queries from the explorer. When enabled, pressing `s` on a table/view appends the generated `SELECT` query below the existing query instead of replacing it, enabling multi-table exploration without losing context.
## Changes
### Explorer (`tree.py`)
- Add `select_table_mode` setting (`append` | `replace`, default `replace`)
- `_get_select_table_mode()` reads mode from `settings_store`
- `_append_generated_query()` appends generated SELECT below current query and positions cursor at end
- `_execute_generated_select()` runs `action_execute_single_statement()` in append mode (executes only the last statement), or `action_execute_query()` in replace mode
- `action_select_table()` branches behavior based on mode
### Shell (`main.py`)
- Add `:set select_table_mode append|replace` command
- Show current mode when invoked without value
- Documented in `:commands` list under Settings
### Tests
- `TestSelectTableMode` class with 2 tests:
  - `test_select_table_mode_replace_keeps_default_behavior` — verifies existing behavior unchanged
  - `test_select_table_mode_append_adds_query_and_executes_only_last_statement` — verifies append + single-statement execution
## Usage
:set select_table_mode append    # Append SELECT queries
:set select_table_mode replace   # Overwrite (default)
:set select_table_mode           # Show current mode
## Stats
- **3 files changed**, +139 / -2 lines
- `tree.py`: +45 (core logic)
- `main.py`: +24 (TUI command)
- `test_cross_database_query.py`: +70 (tests)