### PR TITLE
Use move_cursor instead of select_node

### DIFF
--- a/sqlit/domains/explorer/ui/mixins/tree_filter.py
+++ b/sqlit/domains/explorer/ui/mixins/tree_filter.py
@@ -94,8 +94,8 @@ class TreeFilterMixin:
         node = self._tree_filter_matches[self._tree_filter_match_index]
         # Expand ancestors to make node visible
         self._expand_ancestors(node)
-        # Select the node
-        self.object_tree.select_node(node)
+        # Move cursor to node
+        self.object_tree.move_cursor(node)
 
     def _expand_ancestors(self: TreeFilterMixinHost, node: Any) -> None:
         """Expand all ancestor nodes to make a node visible."""


### PR DESCRIPTION
Thank you for your great work :+1: sqlit is such a joy to use!

---

When filtering the "Explorer" tree it currently uses `select_node` for each match, which results in the node expanding and collapsing each time.

The change I've made is to use `move_cursor` instead.

Before and after:

https://github.com/user-attachments/assets/3204e387-69de-45b0-92a9-768a578a6e88