### PR TITLE
Fix #189: process worker fork-safety on macOS Tahoe

### DIFF
--- a/sqlit/cli.py
+++ b/sqlit/cli.py
@@ -177,6 +177,32 @@ def _sane_tty() -> None:
         pass
 
 
+def _prewarm_process_worker(runtime: RuntimeConfig) -> Any | None:
+    """Spawn the process worker before the Textual App is constructed.
+
+    `multiprocessing.spawn` collects the parent's open file descriptors at
+    spawn time. Textual's `App.__init__` registers signal-handler pipes
+    and other non-inheritable FDs, which cause spawn to abort with
+    `ValueError: bad value(s) in fds_to_keep` (see issue #189). Spawning
+    here — before the App is constructed — is the latest point at which
+    the FD set is still clean.
+
+    Returns the live client, or None if spawn fails or the worker is
+    disabled. On failure we fall through to the lazy path inside the UI;
+    on macOS that path raises and the in-process executor takes over.
+    """
+    if not runtime.process_worker:
+        return None
+    if runtime.mock.enabled:
+        return None
+    try:
+        from sqlit.domains.process_worker.app.process_worker_client import ProcessWorkerClient
+
+        return ProcessWorkerClient()
+    except Exception:
+        return None
+
+
 def _run_app(app: Any) -> int:
     exit_code: int | None = None
     handled_signals = [signal.SIGINT, signal.SIGTERM]
@@ -843,10 +869,14 @@ def main() -> int:
             print(f"Error: {exc}")
             return 1
 
+        # Spawn the worker before the Textual App is constructed; see
+        # _prewarm_process_worker for why this matters on macOS.
+        process_worker_client = _prewarm_process_worker(runtime)
         app = SSMSTUI(
             services=services,
             startup_connection=startup_config,
             exclusive_connection=exclusive_connection,
+            process_worker_client=process_worker_client,
         )
         exit_code = _run_app(app)
         if exit_code != 0:
@@ -907,7 +937,12 @@ def main() -> int:
             print(f"Error: {alert_error}")
             return 1
 
-        app = SSMSTUI(services=services, startup_connection=temp_config)
+        process_worker_client = _prewarm_process_worker(runtime)
+        app = SSMSTUI(
+            services=services,
+            startup_connection=temp_config,
+            process_worker_client=process_worker_client,
+        )
         return _run_app(app)
 
     if args.command in {"connections", "connection"}:

--- a/sqlit/domains/process_worker/app/process_worker.py
+++ b/sqlit/domains/process_worker/app/process_worker.py
@@ -2,13 +2,38 @@
 
 from __future__ import annotations
 
+import faulthandler
+import os
 import pickle
+import sys
+import tempfile
 import threading
 import time
 from collections import deque
 from dataclasses import dataclass, field
 from multiprocessing.connection import Connection
+from pathlib import Path
 from typing import Any
+
+
+def _open_worker_log() -> Any | None:
+    """Open the worker log file, honoring SQLIT_WORKER_LOG when set.
+
+    The parent process may attach this worker to a Textual-managed pipe;
+    libpq notice writes or unexpected stderr output would then SIGPIPE the
+    child. Redirecting both streams to a real file avoids that and gives a
+    place to land C-level fault tracebacks for future diagnosis.
+    """
+    override = os.environ.get("SQLIT_WORKER_LOG")
+    if override:
+        path = Path(override).expanduser()
+    else:
+        path = Path(tempfile.gettempdir()) / "sqlit-worker.log"
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path.open("a", buffering=1)
+    except OSError:
+        return None
 
 from sqlit.domains.connections.domain.config import ConnectionConfig
 from sqlit.domains.connections.providers.catalog import get_provider
@@ -493,6 +518,14 @@ class _WorkerState:
 
 def run_process_worker(conn: Connection) -> None:
     """Process entrypoint for query execution."""
+    log_file = _open_worker_log()
+    if log_file is not None:
+        sys.stdout = log_file
+        sys.stderr = log_file
+        try:
+            faulthandler.enable(file=log_file)
+        except (RuntimeError, ValueError):
+            pass
     state = _WorkerState(conn=conn)
     try:
         while True:

--- a/sqlit/domains/process_worker/app/process_worker_client.py
+++ b/sqlit/domains/process_worker/app/process_worker_client.py
@@ -63,6 +63,14 @@ class ProcessWorkerClient:
             raise error
         if os.name != "posix" or sys.platform.startswith("win"):
             raise error
+        # macOS (especially Tahoe 26+) aborts in the child whenever a forked
+        # process touches CoreFoundation / Security.framework / os_log —
+        # which happens inside psycopg, getaddrinfo, and many other stdlib
+        # paths. Forking here causes hard segfaults (issue #189), so we
+        # surface the spawn failure and let the caller fall back to
+        # in-process execution.
+        if sys.platform == "darwin":
+            raise error
         try:
             self._start_with_context(get_context("fork"))
         except Exception:

--- a/sqlit/domains/shell/app/main.py
+++ b/sqlit/domains/shell/app/main.py
@@ -100,9 +100,16 @@ class SSMSTUI(
         runtime: RuntimeConfig | None = None,
         startup_connection: ConnectionConfig | None = None,
         exclusive_connection: bool = False,
+        process_worker_client: Any | None = None,
     ):
         super().__init__()
         self.services = services or build_app_services(runtime or RuntimeConfig.from_env())
+        # A pre-spawned worker handed in from cli.py, before Textual's
+        # FD set was contaminated. ProcessWorkerLifecycleMixin already
+        # checks self._process_worker_client first, so seeding it here
+        # short-circuits the lazy spawn path.
+        if process_worker_client is not None:
+            self._process_worker_client = process_worker_client
         from sqlit.core.connection_manager import ConnectionManager
 
         self._connection_manager = ConnectionManager(self.services)

--- a/tests/unit/test_cli_prewarm.py
+++ b/tests/unit/test_cli_prewarm.py
@@ -1,0 +1,64 @@
+"""Tests for the pre-spawn helper in cli.py and the SSMSTUI kwarg plumbing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from sqlit.cli import _prewarm_process_worker
+from sqlit.shared.app.runtime import MockConfig, RuntimeConfig
+
+
+def test_prewarm_skipped_when_worker_disabled() -> None:
+    runtime = RuntimeConfig(process_worker=False)
+    with patch("sqlit.domains.process_worker.app.process_worker_client.ProcessWorkerClient") as klass:
+        result = _prewarm_process_worker(runtime)
+    assert result is None
+    klass.assert_not_called()
+
+
+def test_prewarm_skipped_when_mock_enabled() -> None:
+    runtime = RuntimeConfig(process_worker=True, mock=MockConfig(enabled=True))
+    with patch("sqlit.domains.process_worker.app.process_worker_client.ProcessWorkerClient") as klass:
+        result = _prewarm_process_worker(runtime)
+    assert result is None
+    klass.assert_not_called()
+
+
+def test_prewarm_returns_client_when_enabled() -> None:
+    runtime = RuntimeConfig(process_worker=True)
+    sentinel = MagicMock(name="process-worker-client")
+    with patch(
+        "sqlit.domains.process_worker.app.process_worker_client.ProcessWorkerClient",
+        return_value=sentinel,
+    ):
+        result = _prewarm_process_worker(runtime)
+    assert result is sentinel
+
+
+def test_prewarm_swallows_spawn_errors() -> None:
+    """A failing pre-spawn must not break startup; lazy path handles fallback."""
+    runtime = RuntimeConfig(process_worker=True)
+    with patch(
+        "sqlit.domains.process_worker.app.process_worker_client.ProcessWorkerClient",
+        side_effect=ValueError("bad value(s) in fds_to_keep"),
+    ):
+        result = _prewarm_process_worker(runtime)
+    assert result is None
+
+
+def test_ssmstui_stashes_prewarmed_worker() -> None:
+    """A client passed via the kwarg should land on self._process_worker_client.
+
+    ProcessWorkerLifecycleMixin returns that attribute first, so this is
+    what makes the pre-spawn actually short-circuit the lazy path.
+    """
+    from sqlit.domains.shell.app.main import SSMSTUI
+    from tests.ui.mocks import MockConnectionStore, MockSettingsStore, build_test_services, create_test_connection
+
+    services = build_test_services(
+        connection_store=MockConnectionStore([create_test_connection("test-db", "sqlite")]),
+        settings_store=MockSettingsStore({}),
+    )
+    sentinel = MagicMock(name="process-worker-client")
+    app = SSMSTUI(services=services, process_worker_client=sentinel)
+    assert app._process_worker_client is sentinel

--- a/tests/unit/test_process_worker_fallback.py
+++ b/tests/unit/test_process_worker_fallback.py
@@ -1,0 +1,68 @@
+"""Tests for the macOS fork-fallback guard and the worker log redirect."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sqlit.domains.process_worker.app.process_worker import _open_worker_log
+from sqlit.domains.process_worker.app.process_worker_client import ProcessWorkerClient
+
+
+def _make_client_without_init() -> ProcessWorkerClient:
+    """Build a bare ProcessWorkerClient instance without running __init__.
+
+    __init__ spawns a real subprocess; we only want to exercise the
+    in-process branching logic in _maybe_fallback_start.
+    """
+    return ProcessWorkerClient.__new__(ProcessWorkerClient)
+
+
+def test_fork_fallback_disabled_on_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On macOS the fallback path must re-raise instead of forking."""
+    monkeypatch.setattr("sys.platform", "darwin")
+    client = _make_client_without_init()
+
+    error = ValueError("bad value(s) in fds_to_keep")
+    with pytest.raises(ValueError, match="fds_to_keep"):
+        client._maybe_fallback_start(error)
+
+
+def test_fork_fallback_skips_non_fds_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Errors unrelated to fds_to_keep should always re-raise verbatim."""
+    monkeypatch.setattr("sys.platform", "linux")
+    client = _make_client_without_init()
+
+    error = ValueError("totally unrelated message")
+    with pytest.raises(ValueError, match="totally unrelated"):
+        client._maybe_fallback_start(error)
+
+
+def test_worker_log_honors_env_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """SQLIT_WORKER_LOG should redirect the worker log to a custom path."""
+    target = tmp_path / "subdir" / "worker.log"
+    monkeypatch.setenv("SQLIT_WORKER_LOG", str(target))
+
+    log_file = _open_worker_log()
+    assert log_file is not None
+    try:
+        log_file.write("hello\n")
+    finally:
+        log_file.close()
+
+    assert target.exists()
+    assert "hello" in target.read_text()
+
+
+def test_worker_log_returns_none_on_unwritable_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the log path can't be opened, the worker should still boot."""
+    # A path whose parent can't be created (root-owned, non-existent).
+    monkeypatch.setenv("SQLIT_WORKER_LOG", "/proc/definitely/not/writable/here.log")
+
+    log_file = _open_worker_log()
+    assert log_file is None


### PR DESCRIPTION
Thanks again for sqlit — it's the cleanest of the SQL TUIs I've tried.

Fixes #189. macOS Tahoe (26.4+) widened the set of system libraries that abort when initialized after `fork()`, which has been quietly breaking quite a few Python projects (celery, gunicorn, psycopg2 all have open issues from the last few months — links below). For sqlit, the symptom is that the process worker either hangs with `Worker connection closed.` or segfaults the child when expanding a folder or running a query.

This PR has been split per your request (#207 review) — the psycopg v3 driver swap and its supporting adapter/test changes now live in #222.

## Commits

1. **Drop the spawn → fork fallback on darwin; redirect worker stderr.** When `multiprocessing.spawn` fails with `bad value(s) in fds_to_keep`, the current code falls back to `fork()`. On Tahoe that's no longer safe — CoreFoundation, Security.framework, libsystem_trace's `os_log`, and libsystem_info's `getaddrinfo` all now abort if they were loaded by the parent before fork. Letting spawn fail and surfacing it to the caller lets the in-process fallback take over instead. The worker also now redirects its stdout/stderr to `$SQLIT_WORKER_LOG` (defaults to `<tmpdir>/sqlit-worker.log`) and enables `faulthandler`, so future C-level faults aren't invisible behind a closed pipe — that's what let me find the segfault site in the first place.

2. **Pre-spawn the worker in `cli.py` before `App.__init__`.** This is the long-term fix from the issue addendum. `multiprocessing.spawn` snapshots the parent's open FDs at spawn time, and Textual's `App.__init__` registers signal-handler pipes that aren't inheritable — that's the `bad value(s) in fds_to_keep` ValueError. The previous lazy creation in `idle_scheduler.py:_warm` was racing this. Spawning before `SSMSTUI(...)` is constructed is the latest moment at which the FD set is still clean. The pre-spawned client is plumbed in via a new `process_worker_client` kwarg on `SSMSTUI`; `ProcessWorkerLifecycleMixin` already returns the cached client first, so no other changes are needed. If pre-spawn fails for any reason, the lazy path still runs (and on darwin, that path now correctly falls back to in-process execution per commit 1).

3. **Unit tests for the new code paths.** New `tests/unit/test_process_worker_fallback.py` and `tests/unit/test_cli_prewarm.py` cover the darwin re-raise, the worker-log env override, the prewarm gating on `runtime.process_worker` / `runtime.mock`, prewarm exception-swallowing, and the SSMSTUI kwarg plumbing.

## Result on macOS Tahoe 26.4.1 / Python 3.14

| State | Before | After commit 1 only | After both |
| --- | --- | --- | --- |
| Worker crash on tree expand / query | Hard segfault, `Worker connection closed.` | In-process fallback, popup every query | Worker runs, no popup |
| Query latency (25-row PG table over WAN+TLS) | n/a (crash) | ~10s (UI thread blocked) | ~0.5s |
| Query cancellation | Not available | Not available (in-process fallback) | Available |

## Tests

`uv run pytest tests/unit` — 837 passed, 1 skipped, including the 9 new tests in this PR.

## Related upstream regressions on Tahoe (for context — this isn't sqlit-specific)

- celery/celery#9894 — setproctitle abort on Tahoe via libsystem_trace
- benoitc/gunicorn#3526 — NSCharacterSet fork-safety abort on Tahoe
- psycopg/psycopg2#1593 — libssl bundling pulls Security.framework on macOS; psycopg3 fixes
- python/cpython#84559 — CPython 3.14 makes `forkserver` default on POSIX (partial mitigation)

## Tradeoffs to flag

- Commit 1 costs query cancellation on darwin when spawn fails (the in-process fallback can't cancel mid-query). Commit 2 makes that case rare in practice.
- Commit 2 always spawns the worker at startup when `process_worker=True` (the default) — there's no longer an idle-only path on the first launch. Cost: one extra Python subprocess at TUI startup. Benefit: no race, no popup, worker is hot.

Happy to iterate on either commit if you'd prefer a different approach.