### PR TITLE
Navigate filtered nodes with arrow keys + smaller cleanup

### DIFF
--- a/sqlit/domains/explorer/ui/mixins/tree_filter.py
+++ b/sqlit/domains/explorer/ui/mixins/tree_filter.py
@@ -20,7 +20,6 @@ class TreeFilterMixin:
     _tree_filter_text: str = ""
     _tree_filter_query: str = ""
     _tree_filter_fuzzy: bool = False
-    _tree_filter_typing: bool = False
     _tree_filter_matches: list[Any] = []
     _tree_filter_match_index: int = 0
     _tree_original_labels: dict[int, str] = {}
@@ -34,7 +33,6 @@ class TreeFilterMixin:
         self._tree_filter_text = ""
         self._tree_filter_query = ""
         self._tree_filter_fuzzy = False
-        self._tree_filter_typing = True
         self._tree_filter_matches = []
         self._tree_filter_match_index = 0
         self._tree_original_labels = {}
@@ -49,7 +47,6 @@ class TreeFilterMixin:
         self._tree_filter_text = ""
         self._tree_filter_query = ""
         self._tree_filter_fuzzy = False
-        self._tree_filter_typing = False
         self.tree_filter_input.hide()
         self._restore_tree_labels()
         self._show_all_tree_nodes()
@@ -116,40 +113,33 @@ class TreeFilterMixin:
             return
 
         key = event.key
+
         if key == "enter":
             self.action_tree_filter_accept()
             event.prevent_default()
             event.stop()
             return
 
-        if not self._tree_filter_typing:
-            if key in ("n", "j"):
-                self.action_tree_filter_next()
-                event.prevent_default()
-                event.stop()
-                return
-
-            if key in ("N", "k"):
-                self.action_tree_filter_prev()
-                event.prevent_default()
-                event.stop()
-                return
-
-            if key == "/":
-                self.action_tree_filter()
-                event.prevent_default()
-                event.stop()
-                return
-
         # Handle backspace
         if key == "backspace":
-            if self._tree_filter_typing:
-                if self._tree_filter_text:
-                    self._tree_filter_text = self._tree_filter_text[:-1]
-                    self._update_tree_filter()
-                else:
-                    # Exit filter when backspacing with no text
-                    self.action_tree_filter_close()
+            if self._tree_filter_text:
+                self._tree_filter_text = self._tree_filter_text[:-1]
+                self._update_tree_filter()
+            else:
+                # Exit filter when backspacing with no text
+                self.action_tree_filter_close()
+            event.prevent_default()
+            event.stop()
+            return
+
+        if key == "up":
+            self.action_tree_filter_prev()
+            event.prevent_default()
+            event.stop()
+            return
+
+        if key == "down":
+            self.action_tree_filter_next()
             event.prevent_default()
             event.stop()
             return
@@ -158,14 +148,6 @@ class TreeFilterMixin:
         # event.key might be "shift+?" but event.character will be "?"
         char = getattr(event, "character", None)
         if char and char.isprintable():
-            if char == "/" and not self._tree_filter_typing:
-                self.action_tree_filter()
-                event.prevent_default()
-                event.stop()
-                return
-            if not self._tree_filter_typing:
-                super().on_key(event)  # type: ignore[misc]
-                return
             self._tree_filter_text += char
             self._update_tree_filter()
             event.prevent_default()

--- a/sqlit/shared/ui/protocols/explorer.py
+++ b/sqlit/shared/ui/protocols/explorer.py
@@ -14,7 +14,6 @@ class ExplorerStateProtocol(Protocol):
     _tree_filter_text: str
     _tree_filter_query: str
     _tree_filter_fuzzy: bool
-    _tree_filter_typing: bool
     _tree_filter_matches: list[Any]
     _tree_filter_match_index: int
     _tree_original_labels: dict[int, str]


### PR DESCRIPTION
I've added the option to use up and down arrows to select the previous and next filter matches.

I've also removed code relating to `_tree_filter_typing`.

As far as I can see, `_tree_filter_typing` and `_tree_filter_visible` are always in sync (always both `true` or `false`).

And because of this an early exit in `on_key`:
```
if not self._tree_filter_visible:
    # Pass to next mixin in chain (e.g., AutocompleteMixin)
    super().on_key(event)  # type: ignore[misc]
    return
```
I can't see how any of the `not self.tree_filter_typing` statement could be reached.

Again thanks for your work :+1: