### PR TITLE
Skip duplicate auth and cache the Entra token for ad_default mssql

### DIFF
--- a/sqlit/domains/connections/providers/mssql/adapter.py
+++ b/sqlit/domains/connections/providers/mssql/adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import struct
 from typing import TYPE_CHECKING, Any
 
 from sqlit.domains.connections.providers.adapters.base import (
@@ -20,6 +21,22 @@ from sqlit.domains.connections.providers.tls import (
 
 if TYPE_CHECKING:
     from sqlit.domains.connections.domain.config import AuthType, ConnectionConfig
+
+# ODBC connection attribute that lets us hand SQL Server a pre-acquired
+# Entra access token instead of having the driver acquire one itself.
+SQL_COPT_SS_ACCESS_TOKEN = 1256
+
+
+def _build_access_token_struct(token: str) -> bytes:
+    """Pack a JWT into the layout SQL_COPT_SS_ACCESS_TOKEN expects.
+
+    SQL Server's ODBC driver wants a 4-byte little-endian length prefix
+    followed by the token encoded as UTF-16-LE bytes. Same layout the
+    mssql-python driver builds internally; we just produce it ourselves
+    so we can skip the driver's redundant token acquisition.
+    """
+    token_bytes = token.encode("UTF-16-LE")
+    return struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
 
 
 class AzureAdAuthError(Exception):
@@ -166,11 +183,15 @@ class SQLServerAdapter(DatabaseAdapter):
         except Exception:
             pass
 
-    def _build_connection_string(self, config: ConnectionConfig) -> str:
+    def _build_connection_string(self, config: ConnectionConfig, *, attach_token: bool = False) -> str:
         """Build mssql-python connection string from config.
 
         Args:
             config: Connection configuration.
+            attach_token: True when we'll be supplying SQL_COPT_SS_ACCESS_TOKEN
+                ourselves. In that case omit the `Authentication=` directive —
+                the two paths conflict, and the directive would make the driver
+                spawn `az` to acquire its own token, defeating the optimization.
 
         Returns:
             semicolon-delimited key=value connection string.
@@ -200,6 +221,9 @@ class SQLServerAdapter(DatabaseAdapter):
 
         auth = self.get_auth_type(config)
 
+        if attach_token and auth == AuthType.AD_DEFAULT:
+            return base
+
         if auth == AuthType.WINDOWS:
             return base + "Trusted_Connection=yes;"
         elif auth == AuthType.SQL_SERVER:
@@ -225,39 +249,56 @@ class SQLServerAdapter(DatabaseAdapter):
             package_name=self.install_package,
         )
 
-        self._preflight_azure_credentials(config)
+        token = self._preflight_azure_credentials(config)
 
-        conn_str = self._build_connection_string(config)
+        conn_str = self._build_connection_string(config, attach_token=token is not None)
         # Append extra_options to connection string
         for key, value in config.extra_options.items():
             conn_str += f"{key}={value};"
-        conn = mssql_python.connect(conn_str)
+
+        attrs_before: dict[int, bytes] | None = None
+        if token is not None:
+            attrs_before = {SQL_COPT_SS_ACCESS_TOKEN: _build_access_token_struct(token)}
+
+        conn = mssql_python.connect(conn_str, attrs_before=attrs_before)
         # Enable autocommit to allow DDL statements like CREATE DATABASE
         conn.autocommit = True
         return conn
 
-    def _preflight_azure_credentials(self, config: ConnectionConfig) -> None:
-        """Try to acquire a SQL Entra token before opening the SQL connection.
+    def _preflight_azure_credentials(self, config: ConnectionConfig) -> str | None:
+        """Acquire a SQL Entra token and return it for direct ODBC attach.
 
-        Without this, an expired/missing `az login` session surfaces as the
-        ODBC driver's generic "Login failed for user ''" — the real cause
-        ("Please run 'az login'") is buried in stderr. Acquiring the token
-        ourselves lets us raise an actionable AzureAdAuthError.
+        Returning the JWT lets `connect()` hand it to the driver via
+        SQL_COPT_SS_ACCESS_TOKEN, eliminating the duplicate token acquisition
+        the driver would otherwise do when it sees `Authentication=...` in the
+        connection string. Returns None if azure-identity isn't installed or
+        the config isn't ad_default — falls back to driver-side auth.
 
-        Silently no-ops if azure-identity isn't installed (the driver still
-        handles auth — we just lose the nicer error message).
+        A persistent file cache (~5 minute refresh-before-expiry buffer)
+        avoids spawning `az account get-access-token` on every invocation,
+        which dominates cold-start cost for one-shot `sqlit query` runs.
+
+        Failures surface as AzureAdAuthError with an actionable hint
+        ("Please run 'az login'", etc.) instead of the driver's generic
+        "Login failed for user ''".
         """
         import logging
 
         from sqlit.domains.connections.domain.config import AuthType
 
         if self.get_auth_type(config) != AuthType.AD_DEFAULT:
-            return
+            return None
         try:
             from azure.core.exceptions import ClientAuthenticationError
             from azure.identity import DefaultAzureCredential
         except ImportError:
-            return
+            return None
+
+        from . import token_cache
+
+        cached = token_cache.load()
+        if cached is not None:
+            return cached.token
 
         # azure-identity logs the full credential-chain dump to stderr at
         # WARNING level on failure. Our own error already names the actionable
@@ -266,11 +307,21 @@ class SQLServerAdapter(DatabaseAdapter):
         prior_level = azure_logger.level
         azure_logger.setLevel(logging.ERROR)
         try:
-            DefaultAzureCredential().get_token("https://database.windows.net/.default")
+            access_token = DefaultAzureCredential().get_token(
+                "https://database.windows.net/.default"
+            )
         except ClientAuthenticationError as exc:
             raise AzureAdAuthError(_format_azure_ad_hint(exc)) from exc
         finally:
             azure_logger.setLevel(prior_level)
+
+        try:
+            token_cache.save(access_token.token, access_token.expires_on)
+        except OSError:
+            # Cache write failures are non-fatal — we still have the token.
+            pass
+
+        return access_token.token
 
     def get_databases(self, conn: Any) -> list[str]:
         """Get list of databases from SQL Server."""

--- a/sqlit/domains/connections/providers/mssql/token_cache.py
+++ b/sqlit/domains/connections/providers/mssql/token_cache.py
@@ -1,0 +1,66 @@
+"""Persistent file cache for Azure SQL access tokens.
+
+Each `sqlit query` invocation otherwise spawns `az account get-access-token`
+via azure-identity's AzureCliCredential, which costs ~300ms-1s of CLI
+startup. Caching the JWT on disk between invocations makes one-shot queries
+roughly as fast as the SQL roundtrip itself.
+
+The token is stored at 0600 under the user's sqlit config dir. Anyone with
+read access to that file can impersonate the user against Azure SQL for the
+token's remaining lifetime (default 1h) — same tradeoff as caching `az`'s
+own MSAL cache, and the same threat surface as `~/.azure/`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+
+from sqlit.shared.core.store import CONFIG_DIR
+
+CACHE_FILE = CONFIG_DIR / "azure_sql_token.json"
+
+# Tokens are treated as expired this many seconds before their real expiry,
+# so a token acquired here is still good when the ODBC handshake runs.
+_REFRESH_BEFORE_EXPIRY = 300
+
+
+@dataclass(frozen=True)
+class CachedToken:
+    token: str
+    expires_on: int
+
+
+def load() -> CachedToken | None:
+    """Return a cached token if it exists and is comfortably non-expired."""
+    try:
+        data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    expires_on = int(data.get("expires_on", 0))
+    if expires_on <= time.time() + _REFRESH_BEFORE_EXPIRY:
+        return None
+    token = data.get("token")
+    if not isinstance(token, str) or not token:
+        return None
+    return CachedToken(token=token, expires_on=expires_on)
+
+
+def save(token: str, expires_on: int) -> None:
+    """Persist a token atomically with 0600 perms."""
+    CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps({"token": token, "expires_on": int(expires_on)})
+    tmp = CACHE_FILE.with_suffix(".tmp")
+    tmp.write_text(payload, encoding="utf-8")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, CACHE_FILE)
+
+
+def clear() -> None:
+    """Remove the cached token if present."""
+    try:
+        CACHE_FILE.unlink()
+    except FileNotFoundError:
+        pass

--- a/tests/unit/test_mssql_adapter.py
+++ b/tests/unit/test_mssql_adapter.py
@@ -238,9 +238,14 @@ class TestMSSQLAdapterQueries:
 
 
 class TestMSSQLAdapterAzureAdPreflight:
-    """Pre-flight Entra-token check for ad_default auth converts the
-    DefaultAzureCredential chain failure into an actionable AzureAdAuthError
-    *before* the ODBC driver gets to emit its generic "Login failed for user ''".
+    """Pre-flight Entra-token check for ad_default auth.
+
+    The pre-flight does three things:
+    1. Surfaces credential-chain failures as an actionable AzureAdAuthError
+       (vs the driver's generic "Login failed for user ''")
+    2. Returns the JWT so connect() can hand it to the ODBC driver via
+       SQL_COPT_SS_ACCESS_TOKEN, skipping the driver's redundant acquisition
+    3. Caches the JWT on disk to avoid spawning `az` on every invocation
     """
 
     @pytest.fixture
@@ -258,6 +263,16 @@ class TestMSSQLAdapterAzureAdPreflight:
             endpoint=endpoint,
             options={"auth_type": "ad_default"},
         )
+
+    @pytest.fixture(autouse=True)
+    def _empty_token_cache(self):
+        """Patch out the token cache so tests don't depend on the user's
+        ~/.config/sqlit/azure_sql_token.json file."""
+        from sqlit.domains.connections.providers.mssql import token_cache
+
+        with patch.object(token_cache, "load", return_value=None), \
+                patch.object(token_cache, "save"):
+            yield
 
     def test_preflight_surfaces_az_login_hint_on_credential_failure(self, ad_default_config):
         """When DefaultAzureCredential.get_token raises, we raise AzureAdAuthError
@@ -308,8 +323,8 @@ class TestMSSQLAdapterAzureAdPreflight:
         # specific actionable line — keep the error tight, like sqlcmd does.
         assert "DefaultAzureCredential failed to retrieve" not in message
 
-    def test_preflight_noop_when_azure_identity_missing(self, ad_default_config):
-        """If azure-identity is not installed, we silently skip and let the
+    def test_preflight_returns_none_when_azure_identity_missing(self, ad_default_config):
+        """If azure-identity is not installed, we return None and let the
         ODBC driver handle auth (preserving the existing behavior)."""
         from sqlit.domains.connections.providers.mssql.adapter import SQLServerAdapter
 
@@ -324,12 +339,11 @@ class TestMSSQLAdapterAzureAdPreflight:
 
         adapter = SQLServerAdapter()
         with patch("builtins.__import__", side_effect=_block_azure):
-            # Should not raise
-            adapter._preflight_azure_credentials(ad_default_config)
+            assert adapter._preflight_azure_credentials(ad_default_config) is None
 
     def test_preflight_skipped_for_non_ad_default_auth(self):
-        """Pre-flight only runs for ad_default; sql/ad_password etc. must be
-        untouched even if azure-identity would fail."""
+        """Pre-flight only runs for ad_default; sql/ad_password etc. return
+        None and must not touch azure-identity at all."""
         from sqlit.domains.connections.domain.config import (
             ConnectionConfig,
             TcpEndpoint,
@@ -345,5 +359,236 @@ class TestMSSQLAdapterAzureAdPreflight:
         )
 
         adapter = SQLServerAdapter()
-        # Even if azure-identity would explode, this never touches it.
-        adapter._preflight_azure_credentials(config)
+        assert adapter._preflight_azure_credentials(config) is None
+
+    def test_preflight_uses_cached_token_without_calling_credential(self, ad_default_config):
+        """A valid cached token is returned immediately — no az subprocess,
+        no credential-chain probing."""
+        from sqlit.domains.connections.providers.mssql import token_cache
+        from sqlit.domains.connections.providers.mssql.adapter import SQLServerAdapter
+
+        cached = token_cache.CachedToken(token="cached-jwt-value", expires_on=9_999_999_999)
+        fake_azure_identity = MagicMock()
+        fake_azure_identity.DefaultAzureCredential.side_effect = AssertionError(
+            "Credential must not be constructed on cache hit"
+        )
+
+        with patch.object(token_cache, "load", return_value=cached), \
+                patch.dict("sys.modules", {
+                    "azure": MagicMock(),
+                    "azure.core": MagicMock(),
+                    "azure.core.exceptions": MagicMock(),
+                    "azure.identity": fake_azure_identity,
+                }):
+            adapter = SQLServerAdapter()
+            assert adapter._preflight_azure_credentials(ad_default_config) == "cached-jwt-value"
+
+    def test_preflight_saves_freshly_acquired_token_to_cache(self, ad_default_config):
+        """After a successful credential acquisition, the JWT is persisted
+        so subsequent invocations skip the az subprocess."""
+        from sqlit.domains.connections.providers.mssql import token_cache
+        from sqlit.domains.connections.providers.mssql.adapter import SQLServerAdapter
+
+        fake_token = MagicMock()
+        fake_token.token = "freshly-acquired-jwt"
+        fake_token.expires_on = 9_999_999_999
+
+        fake_azure_identity = MagicMock()
+        fake_credential = MagicMock()
+        fake_credential.get_token.return_value = fake_token
+        fake_azure_identity.DefaultAzureCredential.return_value = fake_credential
+
+        with patch.object(token_cache, "save") as save_mock, \
+                patch.dict("sys.modules", {
+                    "azure": MagicMock(),
+                    "azure.core": MagicMock(),
+                    "azure.core.exceptions": MagicMock(),
+                    "azure.identity": fake_azure_identity,
+                }):
+            adapter = SQLServerAdapter()
+            result = adapter._preflight_azure_credentials(ad_default_config)
+
+        assert result == "freshly-acquired-jwt"
+        save_mock.assert_called_once_with("freshly-acquired-jwt", 9_999_999_999)
+
+
+class TestMSSQLAdapterAccessTokenAttach:
+    """connect() must hand the pre-acquired token directly to the ODBC driver
+    via SQL_COPT_SS_ACCESS_TOKEN, *and* strip the conflicting
+    `Authentication=ActiveDirectoryDefault` directive from the conn string.
+    """
+
+    def test_build_connection_string_omits_auth_directive_when_attaching_token(self):
+        """With attach_token=True for ad_default, the conn string must NOT
+        include `Authentication=...` — that directive would make the driver
+        spawn `az` for its own token, defeating the whole optimization."""
+        from sqlit.domains.connections.domain.config import (
+            ConnectionConfig,
+            TcpEndpoint,
+        )
+        from sqlit.domains.connections.providers.mssql.adapter import SQLServerAdapter
+
+        endpoint = TcpEndpoint(host="example.database.windows.net", port="1433", database="mydb")
+        config = ConnectionConfig(
+            name="t",
+            db_type="mssql",
+            endpoint=endpoint,
+            options={"auth_type": "ad_default"},
+        )
+
+        adapter = SQLServerAdapter()
+        without_attach = adapter._build_connection_string(config, attach_token=False)
+        with_attach = adapter._build_connection_string(config, attach_token=True)
+
+        assert "Authentication=ActiveDirectoryDefault" in without_attach
+        assert "Authentication=" not in with_attach
+        assert "SERVER=example.database.windows.net" in with_attach
+        assert "DATABASE=mydb" in with_attach
+
+    def test_access_token_struct_layout_matches_sql_server_protocol(self):
+        """SQL_COPT_SS_ACCESS_TOKEN expects: 4-byte LE length prefix +
+        UTF-16-LE token bytes. This is the exact layout the mssql-python
+        driver builds internally; we replicate it so the driver accepts it."""
+        from sqlit.domains.connections.providers.mssql.adapter import (
+            _build_access_token_struct,
+        )
+
+        token = "abc"
+        result = _build_access_token_struct(token)
+
+        utf16 = token.encode("UTF-16-LE")  # 6 bytes for 3 ASCII chars
+        assert len(utf16) == 6
+        # 4-byte length prefix (LE) + the bytes
+        assert result[:4] == (6).to_bytes(4, "little")
+        assert result[4:] == utf16
+
+    def test_connect_passes_token_via_attrs_before(self):
+        """connect() must call mssql_python.connect() with
+        attrs_before={SQL_COPT_SS_ACCESS_TOKEN: <struct>} when the pre-flight
+        returns a token. This is what eliminates the duplicate auth round."""
+        from sqlit.domains.connections.domain.config import (
+            ConnectionConfig,
+            TcpEndpoint,
+        )
+        from sqlit.domains.connections.providers.mssql.adapter import (
+            SQL_COPT_SS_ACCESS_TOKEN,
+            SQLServerAdapter,
+            _build_access_token_struct,
+        )
+
+        endpoint = TcpEndpoint(host="example.database.windows.net", port="1433", database="mydb")
+        config = ConnectionConfig(
+            name="t",
+            db_type="mssql",
+            endpoint=endpoint,
+            options={"auth_type": "ad_default"},
+        )
+
+        mock_mssql = MagicMock()
+        mock_conn = MagicMock()
+        mock_mssql.connect.return_value = mock_conn
+
+        adapter = SQLServerAdapter()
+        with patch.dict("sys.modules", {"mssql_python": mock_mssql}), \
+                patch.object(SQLServerAdapter, "_preflight_azure_credentials",
+                             return_value="my-jwt"):
+            adapter.connect(config)
+
+        assert mock_mssql.connect.call_count == 1
+        _args, kwargs = mock_mssql.connect.call_args
+        attrs = kwargs.get("attrs_before")
+        assert attrs is not None
+        assert SQL_COPT_SS_ACCESS_TOKEN in attrs
+        assert attrs[SQL_COPT_SS_ACCESS_TOKEN] == _build_access_token_struct("my-jwt")
+
+    def test_connect_passes_attrs_before_none_when_no_token(self):
+        """For non-ad_default auth (no pre-acquired token), attrs_before is
+        None and the driver uses its normal auth path."""
+        from sqlit.domains.connections.domain.config import (
+            ConnectionConfig,
+            TcpEndpoint,
+        )
+        from sqlit.domains.connections.providers.mssql.adapter import SQLServerAdapter
+
+        endpoint = TcpEndpoint(host="h", port="1433", database="d", username="u", password="p")
+        config = ConnectionConfig(
+            name="t",
+            db_type="mssql",
+            endpoint=endpoint,
+            options={"auth_type": "sql"},
+        )
+
+        mock_mssql = MagicMock()
+        mock_mssql.connect.return_value = MagicMock()
+
+        adapter = SQLServerAdapter()
+        with patch.dict("sys.modules", {"mssql_python": mock_mssql}):
+            adapter.connect(config)
+
+        _args, kwargs = mock_mssql.connect.call_args
+        assert kwargs.get("attrs_before") is None
+
+
+class TestMSSQLTokenCache:
+    """File-backed cache for the SQL Entra access token — avoids spawning
+    `az account get-access-token` on every cold `sqlit query` invocation."""
+
+    def test_load_returns_none_when_file_missing(self, tmp_path, monkeypatch):
+        from sqlit.domains.connections.providers.mssql import token_cache
+
+        monkeypatch.setattr(token_cache, "CACHE_FILE", tmp_path / "missing.json")
+        assert token_cache.load() is None
+
+    def test_load_returns_none_when_corrupt_json(self, tmp_path, monkeypatch):
+        from sqlit.domains.connections.providers.mssql import token_cache
+
+        cache_file = tmp_path / "cache.json"
+        cache_file.write_text("not json", encoding="utf-8")
+        monkeypatch.setattr(token_cache, "CACHE_FILE", cache_file)
+        assert token_cache.load() is None
+
+    def test_load_returns_none_when_token_expired(self, tmp_path, monkeypatch):
+        """A token already past its expiry is treated as a cache miss."""
+        import json
+
+        from sqlit.domains.connections.providers.mssql import token_cache
+
+        cache_file = tmp_path / "cache.json"
+        cache_file.write_text(json.dumps({"token": "x", "expires_on": 0}), encoding="utf-8")
+        monkeypatch.setattr(token_cache, "CACHE_FILE", cache_file)
+        assert token_cache.load() is None
+
+    def test_load_returns_none_when_within_refresh_window(self, tmp_path, monkeypatch):
+        """Tokens about to expire (within the 5-minute refresh window) are
+        also treated as a miss so we don't hand the driver a stale token."""
+        import json
+        import time
+
+        from sqlit.domains.connections.providers.mssql import token_cache
+
+        cache_file = tmp_path / "cache.json"
+        cache_file.write_text(
+            json.dumps({"token": "x", "expires_on": int(time.time()) + 60}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(token_cache, "CACHE_FILE", cache_file)
+        assert token_cache.load() is None
+
+    def test_save_then_load_roundtrip(self, tmp_path, monkeypatch):
+        import os
+        import time
+
+        from sqlit.domains.connections.providers.mssql import token_cache
+
+        cache_file = tmp_path / "cache.json"
+        monkeypatch.setattr(token_cache, "CACHE_FILE", cache_file)
+
+        expires = int(time.time()) + 3600
+        token_cache.save("my-jwt", expires)
+
+        loaded = token_cache.load()
+        assert loaded is not None
+        assert loaded.token == "my-jwt"
+        assert loaded.expires_on == expires
+        # 0600 — owner read/write only
+        assert oct(os.stat(cache_file).st_mode & 0o777) == "0o600"


### PR DESCRIPTION
Follow-up to #209. Two compounding optimizations for one-shot `sqlit query` runs against Azure SQL with `ad_default` auth:

1. Hand the pre-acquired JWT directly to mssql-python via `attrs_before={SQL_COPT_SS_ACCESS_TOKEN: ...}` instead of letting the driver acquire its own token. The driver was duplicating the credential-chain probe and re-spawning `az` each time, since #209 only used the pre-flight result to detect failures, not to short-circuit the driver's auth path.
2. Persist the JWT to `CONFIG_DIR/azure_sql_token.json` (0600, atomic write, 5-minute refresh-before-expiry buffer). Subsequent invocations skip the credential acquisition entirely.

Measured against prod Azure SQL from a Linux laptop, 20-row query:

| state | time |
|-------|------|
| Before this PR (driver re-auths) | ~1.2s |
| With this PR, cold (no token cache) | ~1.0s |
| With this PR, token cached | **~0.55s** |

The SQL roundtrip now dominates instead of authentication.

Security note: the cache file holds a 1h-valid JWT in plain JSON under the user's sqlit config dir. Mode 0600 — same threat surface as `~/.azure/msal_token_cache.bin`. Documented in the module docstring.