### PR TITLE
Escape user-typed text in FilterInput to avoid Rich markup crashes

### DIFF
--- a/sqlit/shared/ui/widgets_filter.py
+++ b/sqlit/shared/ui/widgets_filter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from rich.markup import escape as escape_markup
 from textual.widgets import Static
 
 
@@ -54,7 +55,9 @@ class FilterInput(Static):
             # Show "5000+" if results were truncated
             count_display = f"{self.match_count}+" if self.truncated else str(self.match_count)
             count_text = f"[dim]{count_display}/{self.total_count}[/]"
-            self.update(f"[dim]/[/] {self.filter_text} {count_text}")
+            # Escape filter_text so user-typed brackets aren't parsed as Rich markup.
+            safe_text = escape_markup(self.filter_text)
+            self.update(f"[dim]/[/] {safe_text} {count_text}")
 
     def show(self) -> None:
         """Show the filter input."""

--- a/tests/ui/test_filter_input_widget.py
+++ b/tests/ui/test_filter_input_widget.py
@@ -1,0 +1,62 @@
+"""Tests for the shared FilterInput widget.
+
+Regression: typing markup-special characters like '[' into the filter
+must not crash the app. FilterInput interpolates the user-entered
+filter text into a Rich markup string, so the text has to be escaped
+before being passed to Static.update().
+"""
+
+from __future__ import annotations
+
+from rich.markup import render as render_markup
+
+from sqlit.shared.ui.widgets_filter import FilterInput
+
+
+def _rebuild_output(text: str, match_count: int, total: int) -> str:
+    """Drive FilterInput._rebuild without instantiating the Textual widget.
+
+    Capture whatever string would be passed to Static.update().
+    """
+    widget = object.__new__(FilterInput)
+    widget.filter_text = text
+    widget.match_count = match_count
+    widget.total_count = total
+    widget.truncated = False
+
+    captured: list[str] = []
+    widget.update = captured.append  # type: ignore[method-assign]
+    widget._rebuild()
+    assert captured, "_rebuild should call update()"
+    return captured[-1]
+
+
+class TestFilterInputMarkup:
+    """The rendered markup must be well-formed for any user-typed text."""
+
+    def test_plain_text_renders(self):
+        out = _rebuild_output("hello", 2, 10)
+        # Must not raise; should contain the user text.
+        render_markup(out)
+        assert "hello" in out
+
+    def test_open_bracket_does_not_break_markup(self):
+        """Regression: typing '[' produced an unbalanced '[/]' close tag."""
+        out = _rebuild_output("no[", 0, 3)
+        # The crash was here: parsing this string raised MarkupError.
+        render_markup(out)
+
+    def test_close_bracket_does_not_break_markup(self):
+        out = _rebuild_output("foo]", 0, 3)
+        render_markup(out)
+
+    def test_rich_tag_in_filter_text_is_inert(self):
+        """A user typing '[red]' should not actually colorize the display."""
+        out = _rebuild_output("[red]", 0, 3)
+        rendered = render_markup(out)
+        # The escaped text should appear as literal characters in the output.
+        assert "[red]" in rendered.plain
+
+    def test_empty_filter_text_renders(self):
+        out = _rebuild_output("", 0, 0)
+        render_markup(out)


### PR DESCRIPTION
Typing `[` into any filter (tree, results, query history) crashed the app with `MarkupError: auto closing tag ('[/]') has nothing to close`. `FilterInput._rebuild` was interpolating the raw filter text into a Rich markup string, so a stray bracket from the user produced unbalanced tags.

Escape the filter text with `rich.markup.escape` before handing it to `Static.update`. Added a widget-level test covering `[`, `]`, embedded tags, and plain text.