### PR TITLE
Default empty Postgres host to localhost when a port is set

### DIFF
--- a/sqlit/domains/connections/providers/postgresql/adapter.py
+++ b/sqlit/domains/connections/providers/postgresql/adapter.py
@@ -52,8 +52,15 @@ class PostgreSQLAdapter(PostgresBaseAdapter):
             "connect_timeout": 10,
             "database": endpoint.database or "postgres",
         }
-        if endpoint.host:
-            connect_args["host"] = endpoint.host
+        host = endpoint.host
+        # If the user only set a port (e.g. Postgres on a non-default port
+        # like 5433), default the host to "localhost" — matches the Server
+        # field's placeholder. Without this, libpq drops both args and
+        # falls back to the default unix socket, ignoring the port.
+        if not host and endpoint.port:
+            host = "localhost"
+        if host:
+            connect_args["host"] = host
             connect_args["port"] = int(endpoint.port or get_default_port("postgresql"))
         if endpoint.username:
             connect_args["user"] = endpoint.username

--- a/tests/unit/test_postgresql_adapter.py
+++ b/tests/unit/test_postgresql_adapter.py
@@ -32,3 +32,45 @@ def test_postgresql_peer_auth_omits_empty_tcp_args() -> None:
         assert "port" not in kwargs
         assert "user" not in kwargs
         assert "password" not in kwargs
+
+
+def test_postgresql_uses_custom_port_when_server_left_blank() -> None:
+    """Regression test for issue #205.
+
+    A user pointed sqlit at a docker Postgres on 127.0.0.1:5433. They left
+    the Server field blank (its placeholder says 'localhost') and set the
+    Port field to 5433. libpq then reported it couldn't reach
+    /run/postgresql/.s.PGSQL.5432 — i.e. neither host nor port made it
+    through.
+
+    Expected: with a port set, the adapter must pass both port=5433 and
+    a sensible host (localhost, matching the form placeholder) to
+    psycopg2.connect so the connection actually reaches the docker
+    container.
+    """
+    mock_psycopg2 = MagicMock()
+    with patch.dict("sys.modules", {"psycopg2": mock_psycopg2}):
+        from sqlit.domains.connections.providers.postgresql.adapter import PostgreSQLAdapter
+
+        adapter = PostgreSQLAdapter()
+        config = ConnectionConfig(
+            name="timescale",
+            db_type="postgresql",
+            server="",          # blank — UI placeholder says "localhost"
+            port="5433",        # user explicitly chose 5433
+            database="postgres",
+            username="postgres",
+            password="password",
+        )
+
+        adapter.connect(config)
+
+        kwargs = mock_psycopg2.connect.call_args.kwargs
+        assert kwargs.get("port") == 5433, (
+            "port=5433 must reach psycopg2.connect, but the adapter "
+            f"silently drops it when server is blank. kwargs={kwargs!r}"
+        )
+        assert kwargs.get("host") == "localhost", (
+            "blank server must default to 'localhost' (matching the "
+            f"connection form placeholder). kwargs={kwargs!r}"
+        )


### PR DESCRIPTION
Fix #205.