### PR TITLE
UI hints follow the keymap (pane labels + dialog shortcuts); drop quit from user keymap

### DIFF
--- a/config/keymap.template.json
+++ b/config/keymap.template.json
@@ -3,10 +3,12 @@
     "action_keys": {
       "global": {
         "leader_key": "space",
-        "quit": "ctrl+q",
         "cancel_operation": "escape",
         "show_help": "?",
-        "enter_command_mode": ":",
+        "enter_command_mode": [
+          ":",
+          "shift+;"
+        ],
         "undo": "ctrl+z",
         "redo": "ctrl+y"
       },
@@ -224,6 +226,14 @@
         "toggle_value_view_mode": "t",
         "collapse_all_json_nodes": "z",
         "expand_all_json_nodes": "Z"
+      },
+      "error_dialog": {
+        "error_copy_message": "y"
+      },
+      "connection_editor": {
+        "connection_save": "ctrl+s",
+        "connection_test": "ctrl+t",
+        "connection_install_driver": "ctrl+d"
       }
     },
     "leader_commands": {
@@ -237,8 +247,7 @@
         "edit_query_in_editor": "o",
         "show_help": "h",
         "telescope": "space",
-        "telescope_filter": "/",
-        "quit": "q"
+        "telescope_filter": "/"
       },
       "delete": {
         "line": "d",

--- a/sqlit/core/action_validation.py
+++ b/sqlit/core/action_validation.py
@@ -7,11 +7,24 @@ from typing import Any
 from sqlit.core.keymap import get_keymap
 from sqlit.core.leader_commands import get_leader_commands
 
+# Contexts whose actions live on a Screen class, not on the App. These are
+# routed via Textual's per-screen Binding system; their action methods are
+# defined on the screen they belong to, so checking the App for them would
+# always miss. Skipped by the validator.
+_SCREEN_LOCAL_CONTEXTS: frozenset[str] = frozenset(
+    {
+        "error_dialog",
+        "connection_editor",
+    }
+)
+
 
 def validate_actions(app: Any) -> list[str]:
     missing: set[str] = set()
 
     for action_key in get_keymap().get_action_keys():
+        if action_key.context in _SCREEN_LOCAL_CONTEXTS:
+            continue
         action_name = f"action_{action_key.action}"
         if not hasattr(app, action_name):
             missing.add(action_name)

--- a/sqlit/core/keymap.py
+++ b/sqlit/core/keymap.py
@@ -484,6 +484,13 @@ class DefaultKeymapProvider(KeymapProvider):
             ActionKeyDef("t", "toggle_value_view_mode", "value_view"),
             ActionKeyDef("z", "collapse_all_json_nodes", "value_view"),
             ActionKeyDef("Z", "expand_all_json_nodes", "value_view"),
+            # Error dialog (screen-local — action methods live on ErrorScreen,
+            # not the App; the validator skips this context for that reason)
+            ActionKeyDef("y", "error_copy_message", "error_dialog"),
+            # Connection editor (screen-local, same as above)
+            ActionKeyDef("ctrl+s", "connection_save", "connection_editor"),
+            ActionKeyDef("ctrl+t", "connection_test", "connection_editor"),
+            ActionKeyDef("ctrl+d", "connection_install_driver", "connection_editor"),
         ]
 
 

--- a/sqlit/core/keymap.py
+++ b/sqlit/core/keymap.py
@@ -206,7 +206,6 @@ class DefaultKeymapProvider(KeymapProvider):
             LeaderCommandDef("h", "show_help", "Help", "Actions"),
             LeaderCommandDef("space", "telescope", "Telescope", "Actions"),
             LeaderCommandDef("slash", "telescope_filter", "Telescope Search", "Actions"),
-            LeaderCommandDef("q", "quit", "Quit", "Actions"),
             # Delete menu (vim-style)
             LeaderCommandDef("d", "line", "Delete line", "Delete", menu="delete"),
             LeaderCommandDef("w", "word", "Delete word", "Delete", menu="delete"),
@@ -337,7 +336,10 @@ class DefaultKeymapProvider(KeymapProvider):
             ActionKeyDef("enter", "tree_filter_accept", "tree_filter"),
             # Global
             ActionKeyDef("space", "leader_key", "global", priority=True),
-            ActionKeyDef("ctrl+q", "quit", "global"),
+            # quit is intentionally not in the user-overridable keymap;
+            # it lives only as Textual's built-in App.BINDINGS (ctrl+q) and
+            # the `:q` command. Keeping it un-rebindable avoids the footgun
+            # of a user accidentally locking themselves out of the exit key.
             ActionKeyDef("escape", "cancel_operation", "global"),
             ActionKeyDef("question_mark", "show_help", "global"),
             ActionKeyDef("colon", "enter_command_mode", "global"),

--- a/sqlit/domains/connections/ui/screens/connection.py
+++ b/sqlit/domains/connections/ui/screens/connection.py
@@ -50,9 +50,9 @@ class ConnectionScreen(ModalScreen):
 
     BINDINGS = [
         Binding("escape", "cancel", "Cancel", priority=True),
-        Binding("ctrl+s", "save", "Save", priority=True),
-        Binding("ctrl+t", "test_connection", "Test", priority=True),
-        Binding("ctrl+d", "install_driver", "Install driver", show=False, priority=True),
+        Binding("ctrl+s", "save", "Save", priority=True, id="connection_save"),
+        Binding("ctrl+t", "test_connection", "Test", priority=True, id="connection_test"),
+        Binding("ctrl+d", "install_driver", "Install driver", show=False, priority=True, id="connection_install_driver"),
         Binding("tab", "next_field", "Next field", priority=True),
         Binding("shift+tab", "prev_field", "Previous field", priority=True),
         Binding("down", "focus_tab_content", "Focus content", show=False),
@@ -306,7 +306,12 @@ class ConnectionScreen(ModalScreen):
         title = "Edit Connection" if self.editing else "New Connection"
         db_type = self._form.current_db_type
 
-        shortcuts = [("Test", "^t"), ("Save", "^s"), ("Cancel", "<esc>")]
+        from sqlit.core.keymap import format_key, get_keymap
+
+        km = get_keymap()
+        test_key = format_key(km.action("connection_test") or "ctrl+t")
+        save_key = format_key(km.action("connection_save") or "ctrl+s")
+        shortcuts = [("Test", test_key), ("Save", save_key), ("Cancel", "<esc>")]
         initial_values = self._form.get_initial_visibility_values()
 
         with Dialog(id="connection-dialog", title=title, shortcuts=shortcuts):

--- a/sqlit/domains/results/ui/screens/value_view.py
+++ b/sqlit/domains/results/ui/screens/value_view.py
@@ -88,11 +88,17 @@ class ValueViewScreen(ModalScreen):
         return self._raw_value
 
     def compose(self) -> ComposeResult:
-        shortcuts = [("Copy", "y"), ("Close", "<enter>")]
+        from sqlit.core.keymap import format_key, get_keymap
+
+        km = get_keymap()
+        copy_key = format_key(km.action("copy_value_view") or "y")
+        toggle_key = format_key(km.action("toggle_value_view_mode") or "t")
+        collapse_key = format_key(km.action("collapse_all_json_nodes") or "z")
+        shortcuts = [("Copy", copy_key), ("Close", "<enter>")]
         if self._is_json:
             # Start in tree mode, so show "Syntax View" as what we'd switch to
-            shortcuts.insert(0, ("Syntax View", "t"))
-            shortcuts.insert(0, ("Collapse", "z"))
+            shortcuts.insert(0, ("Syntax View", toggle_key))
+            shortcuts.insert(0, ("Collapse", collapse_key))
         with Dialog(id="value-dialog", title=self._title, shortcuts=shortcuts):
             with VerticalScroll(id="value-scroll", classes="hidden"):
                 yield Static(self._format_syntax_value(), id="value-text", markup=False)

--- a/sqlit/domains/shell/app/main.py
+++ b/sqlit/domains/shell/app/main.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from textual.app import App, ComposeResult
+from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
 from textual.events import Key
 from textual.lazy import Lazy
@@ -77,6 +78,7 @@ class SSMSTUI(
     ResultsFilterMixin,
     UINavigationMixin,
     App,
+    inherit_bindings=False,
 ):
     """Main SSMS TUI application."""
 
@@ -85,7 +87,14 @@ class SSMSTUI(
 
     LAYERS = ["autocomplete"]
 
-    BINDINGS: ClassVar[list[Any]] = []
+    # We opt out of Textual's inherited App.BINDINGS so the keymap is the
+    # single source of truth for what keys do. We re-declare the quit
+    # binding here with id="quit" so the keymap-driven `app.set_keymap()`
+    # call in startup_flow can remap it (Textual's keymap remapping is
+    # id-based; the framework default has no id).
+    BINDINGS: ClassVar[list[Any]] = [
+        Binding("ctrl+q", "quit", "Quit", priority=True, show=False, id="quit"),
+    ]
 
     query_executing: bool = reactive(False)
     current_connection: Any | None = reactive(None)

--- a/sqlit/domains/shell/app/main.py
+++ b/sqlit/domains/shell/app/main.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 from textual.app import App, ComposeResult
-from textual.binding import Binding
 from textual.containers import Container, Horizontal, Vertical
 from textual.events import Key
 from textual.lazy import Lazy
@@ -78,7 +77,6 @@ class SSMSTUI(
     ResultsFilterMixin,
     UINavigationMixin,
     App,
-    inherit_bindings=False,
 ):
     """Main SSMS TUI application."""
 
@@ -87,14 +85,7 @@ class SSMSTUI(
 
     LAYERS = ["autocomplete"]
 
-    # We opt out of Textual's inherited App.BINDINGS so the keymap is the
-    # single source of truth for what keys do. We re-declare the quit
-    # binding here with id="quit" so the keymap-driven `app.set_keymap()`
-    # call in startup_flow can remap it (Textual's keymap remapping is
-    # id-based; the framework default has no id).
-    BINDINGS: ClassVar[list[Any]] = [
-        Binding("ctrl+q", "quit", "Quit", priority=True, show=False, id="quit"),
-    ]
+    BINDINGS: ClassVar[list[Any]] = []
 
     query_executing: bool = reactive(False)
     current_connection: Any | None = reactive(None)

--- a/sqlit/domains/shell/ui/mixins/ui_status.py
+++ b/sqlit/domains/shell/ui/mixins/ui_status.py
@@ -109,9 +109,16 @@ class UIStatusMixin:
                 # Inactive pane: key and title match border color via CSS
                 pane.border_title = f"\\[{key}] {label}"
 
-        set_title(pane_explorer, "e", explorer_label, active=active_pane == "explorer")
-        set_title(pane_query, "q", "Query", active=active_pane == "query")
-        set_title(pane_results, "r", "Results", active=active_pane == "results")
+        from sqlit.core.keymap import format_key, get_keymap
+
+        km = get_keymap()
+        explorer_key = format_key(km.action("focus_explorer") or "e")
+        query_key = format_key(km.action("focus_query") or "q")
+        results_key = format_key(km.action("focus_results") or "r")
+
+        set_title(pane_explorer, explorer_key, explorer_label, active=active_pane == "explorer")
+        set_title(pane_query, query_key, "Query", active=active_pane == "query")
+        set_title(pane_results, results_key, "Results", active=active_pane == "results")
 
     def _update_vim_mode_visuals(self: UINavigationMixinHost) -> None:
         """Update all visual indicators based on current vim mode.

--- a/sqlit/shared/ui/screens/error.py
+++ b/sqlit/shared/ui/screens/error.py
@@ -15,7 +15,7 @@ class ErrorScreen(ModalScreen):
 
     BINDINGS = [
         Binding("enter,escape", "close", "Close"),
-        Binding("y", "copy_message", "Copy"),
+        Binding("y", "copy_message", "Copy", id="error_copy_message"),
     ]
 
     CSS = """
@@ -44,7 +44,11 @@ class ErrorScreen(ModalScreen):
         self.message = message
 
     def compose(self) -> ComposeResult:
-        shortcuts = [("Copy", "y"), ("Close", "<enter>")]
+        from sqlit.core.keymap import format_key, get_keymap
+
+        km = get_keymap()
+        copy_key = format_key(km.action("error_copy_message") or "y")
+        shortcuts = [("Copy", copy_key), ("Close", "<enter>")]
         with Dialog(id="error-dialog", title=self.title_text, shortcuts=shortcuts):
             yield Static(self.message, id="error-message")
 

--- a/tests/ui/keybindings/test_keymap_manager.py
+++ b/tests/ui/keybindings/test_keymap_manager.py
@@ -134,7 +134,7 @@ class TestSimpleRemap:
         _load(
             tmp_path,
             "small",
-            {"keymap": {"leader_commands": {"leader": {"quit": "Z"}}}},
+            {"keymap": {"leader_commands": {"leader": {"change_theme": "Z"}}}},
         )
         keymap = get_keymap()
         # toggle_explorer wasn't touched — still on its default 'e'.
@@ -438,11 +438,11 @@ class TestConflicts:
         assert "Conflicting keybindings detected" in manager.load_error
 
     def test_user_vs_default_leader(self, tmp_path: Path):
-        # Default: <leader>e → toggle_explorer. User binds <leader>e → quit.
+        # Default: <leader>e → toggle_explorer. User binds <leader>e → change_theme.
         manager = _load(
             tmp_path,
             "leader-conflict",
-            {"keymap": {"leader_commands": {"leader": {"quit": "e"}}}},
+            {"keymap": {"leader_commands": {"leader": {"change_theme": "e"}}}},
         )
         assert manager.load_error is not None
         assert "leader key 'e'" in manager.load_error

--- a/tests/ui/keybindings/test_keymap_provider.py
+++ b/tests/ui/keybindings/test_keymap_provider.py
@@ -21,8 +21,8 @@ class TestKeymapProvider:
         """Default keymap should have standard leader commands."""
         keymap = get_keymap()
 
-        # Verify leader commands exist (don't check specific keys)
-        assert keymap.leader("quit") is not None
+        # Verify leader commands exist (don't check specific keys).
+        # quit is intentionally NOT in the user-overridable keymap.
         assert keymap.leader("show_help") is not None
         assert keymap.leader("toggle_explorer") is not None
         assert keymap.leader("change_theme") is not None


### PR DESCRIPTION
Two related fixes so the keymap actually drives what the user sees in the UI.

**1. UI hints showed stale keys.** The pane border labels (`[e] Explorer`, `[q] Query`, `[r] Results`) in `ui_status.py` were hardcoded. Remapping `focus_explorer` to `E` left the border still showing `[e]`. Same problem in three dialog shortcut hints:
- `ValueViewScreen` — `Copy: y`, `Toggle: t`, `Collapse: z`
- `ErrorScreen` — `Copy: y`
- `ConnectionScreen` — `Test: ^t`, `Save: ^s`

All now read from the keymap.

**2. Quit is no longer user-overridable.** The earlier attempt to make `ctrl+q` keymap-driven (by overriding Textual's `App.BINDINGS`) is reverted — quit is the kind of key nobody benefits from rebinding, and giving it special treatment created a foot-gun where a typo in `keymap.json` could lock the user out of the exit key. Textual's hardcoded `ctrl+q -> quit` and `ctrl+c -> help_quit` stay as the only routes (plus the `:q` command).

To support screen-local actions (`error_copy_message`, `connection_save`, `connection_test`, `connection_install_driver`) cleanly, adds two new contexts (`error_dialog`, `connection_editor`) and teaches the action validator to skip them — their action methods live on the Screen, not the App.