### PR TITLE
feat(keybindings): in-app keybinding editor (leader+k)

### DIFF
--- a/sqlit/core/keymap.py
+++ b/sqlit/core/keymap.py
@@ -204,6 +204,7 @@ class DefaultKeymapProvider(KeymapProvider):
                 "Actions",
             ),
             LeaderCommandDef("h", "show_help", "Help", "Actions"),
+            LeaderCommandDef("k", "show_keybinding_editor", "Edit Keybindings", "Actions"),
             LeaderCommandDef("space", "telescope", "Telescope", "Actions"),
             LeaderCommandDef("slash", "telescope_filter", "Telescope Search", "Actions"),
             # Delete menu (vim-style)

--- a/sqlit/core/state_base.py
+++ b/sqlit/core/state_base.py
@@ -97,6 +97,15 @@ class State(ABC):
     """Base class for hierarchical states."""
 
     help_category: str | None = None
+    # Name this state uses in keymap defaults / user config (e.g. the
+    # ``context`` field of :class:`~sqlit.core.keymap.ActionKeyDef`). Used
+    # by the keymap-manager's conflict detector to derive ancestor chains
+    # from this state's :attr:`parent` link — so binding the same key in
+    # a descendant context to a *different* action than an ancestor's
+    # binding is caught before it lands on disk. ``None`` means the
+    # state has no corresponding keymap context (intermediate/composite
+    # states like ``QueryFocusedState`` and the modal-only screens).
+    keymap_context: str | None = None
 
     def __init__(self, parent: State | None = None):
         self.parent = parent

--- a/sqlit/domains/explorer/state/tree_filter_active.py
+++ b/sqlit/domains/explorer/state/tree_filter_active.py
@@ -10,6 +10,7 @@ class TreeFilterActiveState(BlockingState):
     """State when tree filter is active."""
 
     help_category = "Explorer"
+    keymap_context = "tree_filter"
 
     def _setup_actions(self) -> None:
         self.allows("tree_filter_close", help="Close filter")

--- a/sqlit/domains/explorer/state/tree_focused.py
+++ b/sqlit/domains/explorer/state/tree_focused.py
@@ -10,6 +10,7 @@ class TreeFocusedState(State):
     """Base state when tree has focus."""
 
     help_category = "Explorer"
+    keymap_context = "tree"
 
     def _setup_actions(self) -> None:
         self.allows("new_connection", label="New", help="New connection")

--- a/sqlit/domains/explorer/state/tree_visual_mode.py
+++ b/sqlit/domains/explorer/state/tree_visual_mode.py
@@ -10,6 +10,7 @@ class TreeVisualModeState(State):
     """Tree focused in visual selection mode (vim-style range selection)."""
 
     help_category = "Explorer"
+    keymap_context = "tree_visual"
 
     def _setup_actions(self) -> None:
         self.allows(

--- a/sqlit/domains/query/state/autocomplete_active.py
+++ b/sqlit/domains/query/state/autocomplete_active.py
@@ -11,6 +11,7 @@ class AutocompleteActiveState(State):
     """Query editor with autocomplete dropdown visible."""
 
     help_category = "Query Editor (Insert)"
+    keymap_context = "autocomplete"
 
     def _setup_actions(self) -> None:
         self.allows("autocomplete_next", help="Next suggestion", help_key="^j")

--- a/sqlit/domains/query/state/query_insert.py
+++ b/sqlit/domains/query/state/query_insert.py
@@ -11,6 +11,7 @@ class QueryInsertModeState(State):
     """Query editor in INSERT mode."""
 
     help_category = "Query Editor (Insert)"
+    keymap_context = "query_insert"
 
     def _setup_actions(self) -> None:
         self.allows("exit_insert_mode", label="Normal Mode", help="Exit to NORMAL mode")

--- a/sqlit/domains/query/state/query_normal.py
+++ b/sqlit/domains/query/state/query_normal.py
@@ -11,6 +11,7 @@ class QueryNormalModeState(State):
     """Query editor in NORMAL mode."""
 
     help_category = "Query Editor (Normal)"
+    keymap_context = "query_normal"
 
     def _setup_actions(self) -> None:
         self.allows("enter_insert_mode", label="Insert Mode", help="Enter INSERT mode")

--- a/sqlit/domains/query/state/query_visual.py
+++ b/sqlit/domains/query/state/query_visual.py
@@ -11,6 +11,7 @@ class QueryVisualModeState(State):
     """Query editor in VISUAL mode (v)."""
 
     help_category = "Query Editor (Visual)"
+    keymap_context = "query_visual"
 
     def _setup_actions(self) -> None:
         self.allows(

--- a/sqlit/domains/query/state/query_visual_line.py
+++ b/sqlit/domains/query/state/query_visual_line.py
@@ -11,6 +11,7 @@ class QueryVisualLineModeState(State):
     """Query editor in VISUAL LINE mode (V)."""
 
     help_category = "Query Editor (Visual Line)"
+    keymap_context = "query_visual_line"
 
     def _setup_actions(self) -> None:
         self.allows(

--- a/sqlit/domains/results/state/results_filter_active.py
+++ b/sqlit/domains/results/state/results_filter_active.py
@@ -10,6 +10,7 @@ class ResultsFilterActiveState(BlockingState):
     """State when results filter is active."""
 
     help_category = "Results"
+    keymap_context = "results_filter"
 
     def _setup_actions(self) -> None:
         self.allows("results_filter_close", help="Close filter", help_key="esc")

--- a/sqlit/domains/results/state/results_focused.py
+++ b/sqlit/domains/results/state/results_focused.py
@@ -10,6 +10,7 @@ class ResultsFocusedState(State):
     """Results table has focus."""
 
     help_category = "Results"
+    keymap_context = "results"
 
     def _setup_actions(self) -> None:
         def has_results(app: InputContext) -> bool:

--- a/sqlit/domains/results/state/value_view_active.py
+++ b/sqlit/domains/results/state/value_view_active.py
@@ -10,6 +10,7 @@ class ValueViewActiveState(State):
     """Base state for inline value view (viewing a cell's full content)."""
 
     help_category = "Value View"
+    keymap_context = "value_view"
 
     def _setup_actions(self) -> None:
         self.allows("close_value_view", key="escape", label="Close", help="Close value view")

--- a/sqlit/domains/shell/app/keymap_manager.py
+++ b/sqlit/domains/shell/app/keymap_manager.py
@@ -1,13 +1,8 @@
 """Loads the user's custom keymap and registers it with the core keymap.
 
-Follows the same domain-service pattern as
-[`ThemeManager`][sqlit.domains.shell.app.theme_manager] — a settings-driven
-configuration step run during app startup. The loader looks for, in order:
-
-1. A named keymap selected by the ``custom_keymap`` setting, resolved
-   relative to ``<CONFIG_DIR>/keymaps/<name>.json`` (or an absolute path).
-2. ``<CONFIG_DIR>/keymap.json`` if it exists — picked up automatically
-   so a user can customize without editing settings.json.
+There is exactly one keymap file: ``<CONFIG_DIR>/keymap.json``. It's
+auto-created as an empty scaffold on first run and overwritten in place
+by the in-app keybinding editor — no separate "named keymap" indirection.
 
 ``CONFIG_DIR`` resolves to ``$SQLIT_CONFIG_DIR`` if set, otherwise
 ``$XDG_CONFIG_HOME/sqlit`` (defaulting to ``~/.config/sqlit``). See
@@ -58,12 +53,57 @@ from sqlit.core.keymap import (
 from sqlit.shared.core.protocols import SettingsStoreProtocol
 from sqlit.shared.core.store import CONFIG_DIR
 
-CUSTOM_KEYMAP_SETTINGS_KEY = "custom_keymap"
-CUSTOM_KEYMAP_DIR = CONFIG_DIR / "keymaps"
-# Picked up automatically when no `custom_keymap` setting is present.
-# Lets a user customize their bindings by dropping a single file in
-# their config dir — no settings edit, no mkdir.
+# The only keymap file. Auto-scaffolded on first run; the in-app
+# editor writes here.
 DEFAULT_KEYMAP_FILE = CONFIG_DIR / "keymap.json"
+
+_CONTEXT_ANCESTORS_CACHE: dict[str, tuple[str, ...]] | None = None
+
+
+def _context_ancestors() -> dict[str, tuple[str, ...]]:
+    """Walk :class:`UIStateMachine` once to build descendant→ancestors.
+
+    Each ``State`` subclass that maps to a keymap context declares its
+    own name via the ``keymap_context`` class attribute (see
+    :class:`sqlit.core.state_base.State`). The state machine wires the
+    parent chain, so the hierarchy used by the runtime resolver is the
+    *only* source of truth — the conflict detector just walks it.
+
+    Modal-only screens (error dialog, connection editor) carry their
+    own bindings and don't appear in :class:`UIStateMachine`, so they
+    sit outside any chain — their context names simply don't appear in
+    the returned map.
+    """
+    global _CONTEXT_ANCESTORS_CACHE
+    if _CONTEXT_ANCESTORS_CACHE is not None:
+        return _CONTEXT_ANCESTORS_CACHE
+
+    # Local import so importing this module at app startup doesn't drag
+    # in every State subclass before it's actually needed (also avoids
+    # the latent circular-import risk between shell and core modules).
+    from sqlit.domains.shell.state.machine import UIStateMachine
+
+    machine = UIStateMachine()
+    ancestors: dict[str, tuple[str, ...]] = {}
+    for state in machine._states:
+        ctx = state.keymap_context
+        if ctx is None:
+            continue
+        chain: list[str] = []
+        cur = state.parent
+        while cur is not None:
+            anc_ctx = cur.keymap_context
+            if anc_ctx is not None and anc_ctx != ctx:
+                chain.append(anc_ctx)
+            cur = cur.parent
+        ancestors[ctx] = tuple(chain)
+    # Root context itself: no ancestors, but it needs an entry so
+    # downstream lookups don't ``KeyError``.
+    if machine.root.keymap_context is not None:
+        ancestors.setdefault(machine.root.keymap_context, ())
+
+    _CONTEXT_ANCESTORS_CACHE = ancestors
+    return ancestors
 
 # Friendly literal characters → the canonical Textual key name(s) they
 # expand to. Lets the user write `"?"` instead of `"question_mark"` and
@@ -175,33 +215,147 @@ class KeymapManager:
         # so the user sees it in the UI instead of only on stderr. None when
         # the most recent load succeeded or no custom keymap was requested.
         self.load_error: str | None = None
+        # Path of the file we most recently loaded — the editor writes to
+        # this so live edits actually round-trip through the same file the
+        # loader will re-read.
+        self.active_path: Path | None = None
 
     def initialize(self) -> dict:
         settings = self._settings_store.load_all()
         self.load_custom_keymap(settings)
         return settings
 
-    def load_custom_keymap(self, settings: dict) -> None:
-        self.load_error = None
-        keymap_name = settings.get(CUSTOM_KEYMAP_SETTINGS_KEY)
-        if isinstance(keymap_name, str) and keymap_name.strip() not in ("", "default"):
-            # Explicit named keymap from settings — power-user path.
-            try:
-                path = self._resolve_keymap_path(keymap_name.strip())
-                self._register_custom_keymap(path, keymap_name.strip())
-            except Exception as exc:
-                self.load_error = f"Failed to load custom keymap '{keymap_name}': {exc}"
-            return
+    def load_custom_keymap(self, settings: dict) -> None:  # noqa: ARG002
+        """Load (or auto-scaffold) ``~/.config/sqlit/keymap.json``.
 
-        # No setting → load the default file, creating an empty scaffold if
-        # it doesn't exist so the file is discoverable in the user's config
-        # dir even before they've customized anything.
+        The ``settings`` argument is kept for signature compatibility with
+        the rest of startup — it used to drive a ``custom_keymap`` named
+        path, but that indirection has been removed in favour of a single
+        on-disk file the in-app editor owns.
+        """
+        self.load_error = None
         self._ensure_default_keymap_scaffold()
+        self.active_path = DEFAULT_KEYMAP_FILE
         if DEFAULT_KEYMAP_FILE.exists():
             try:
                 self._register_custom_keymap(DEFAULT_KEYMAP_FILE, DEFAULT_KEYMAP_FILE.name)
             except Exception as exc:
                 self.load_error = f"Failed to load {DEFAULT_KEYMAP_FILE}: {exc}"
+
+    def reload(self) -> None:
+        """Reload the keymap from disk and re-publish it via set_keymap().
+
+        Called by the in-app keybinding editor after it writes a change to
+        the active keymap file. On parse/validation errors the error is
+        surfaced via :attr:`load_error` and the previously-installed keymap
+        stays active.
+        """
+        from sqlit.core.keymap import reset_keymap
+
+        # Drop the cached provider so an error path leaves us on defaults
+        # rather than stale user overrides.
+        reset_keymap()
+        settings = self._settings_store.load_all()
+        self.load_custom_keymap(settings)
+        if self.load_error:
+            raise ValueError(self.load_error)
+
+    # ---------------------------------------------------------------- editing
+
+    def edit_action_key(
+        self,
+        state: str,
+        action: str,
+        keys: str | list[str] | None,
+    ) -> None:
+        """Set or unset a user override for ``action_keys[state][action]``.
+
+        Passing ``None`` removes the override (default reapplies). Writes to
+        :attr:`active_path` then triggers a reload.
+        """
+        payload = self._read_payload_for_edit()
+        keymap_data = self._keymap_section(payload)
+        action_keys = keymap_data.setdefault("action_keys", {})
+        if not isinstance(action_keys, dict):
+            action_keys = {}
+            keymap_data["action_keys"] = action_keys
+        state_map = action_keys.setdefault(state, {})
+        if not isinstance(state_map, dict):
+            state_map = {}
+            action_keys[state] = state_map
+        if keys is None:
+            state_map.pop(action, None)
+            if not state_map:
+                action_keys.pop(state, None)
+        else:
+            state_map[action] = keys
+        self._write_payload_and_reload(payload)
+
+    def edit_leader_command(
+        self,
+        menu: str,
+        action: str,
+        key: str | None,
+    ) -> None:
+        """Set or unset a user override for ``leader_commands[menu][action]``."""
+        payload = self._read_payload_for_edit()
+        keymap_data = self._keymap_section(payload)
+        leader = keymap_data.setdefault("leader_commands", {})
+        if not isinstance(leader, dict):
+            leader = {}
+            keymap_data["leader_commands"] = leader
+        menu_map = leader.setdefault(menu, {})
+        if not isinstance(menu_map, dict):
+            menu_map = {}
+            leader[menu] = menu_map
+        if key is None:
+            menu_map.pop(action, None)
+            if not menu_map:
+                leader.pop(menu, None)
+        else:
+            menu_map[action] = key
+        self._write_payload_and_reload(payload)
+
+    def reset_all(self) -> None:
+        """Wipe all user overrides — writes an empty scaffold and reloads."""
+        payload = {"keymap": {"action_keys": {}, "leader_commands": {}}}
+        self._write_payload_and_reload(payload)
+
+    def _read_payload_for_edit(self) -> dict:
+        path = self.active_path or DEFAULT_KEYMAP_FILE
+        if not path.exists():
+            return {"keymap": {"action_keys": {}, "leader_commands": {}}}
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            # Corrupt file — overwrite with a fresh scaffold rather than
+            # silently propagating the parse error to the user's edit.
+            return {"keymap": {"action_keys": {}, "leader_commands": {}}}
+        if not isinstance(raw, dict):
+            return {"keymap": {"action_keys": {}, "leader_commands": {}}}
+        return raw
+
+    @staticmethod
+    def _keymap_section(payload: dict) -> dict:
+        section = payload.get("keymap")
+        if not isinstance(section, dict):
+            section = {}
+            payload["keymap"] = section
+        return section
+
+    def _write_payload_and_reload(self, payload: dict) -> None:
+        # Validate first — if the proposed edit collides with another
+        # binding (or fails parse / reference checks), surface the error
+        # without touching the on-disk keymap. The user's last good config
+        # stays in effect.
+        self.validate_payload(payload)
+        path = self.active_path or DEFAULT_KEYMAP_FILE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(payload, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        self.reload()
 
     @staticmethod
     def _ensure_default_keymap_scaffold() -> None:
@@ -222,13 +376,6 @@ class KeymapManager:
             # can still create the file themselves.
             pass
 
-    def _resolve_keymap_path(self, keymap_name: str) -> Path:
-        if keymap_name.startswith(("~", "/")) or Path(keymap_name).is_absolute():
-            return Path(keymap_name).expanduser()
-
-        name = Path(keymap_name).stem
-        return CUSTOM_KEYMAP_DIR / f"{name}.json"
-
     def _register_custom_keymap(self, path: Path, keymap_name: str) -> None:
         path = path.expanduser()
         if not path.exists():
@@ -242,7 +389,17 @@ class KeymapManager:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except Exception as exc:
             raise ValueError(f"Failed to read keymap JSON: {exc}") from exc
+        return self._build_provider_from_payload(payload, keymap_name)
 
+    def _build_provider_from_payload(
+        self, payload: Any, keymap_name: str
+    ) -> FileBasedKeymapProvider:
+        """Parse + merge + validate a keymap payload.
+
+        Used by the file loader and by :meth:`validate_payload` — anything
+        the in-app editor would commit to disk must pass through this so
+        we catch conflicts before writing, not after the next restart.
+        """
         if not isinstance(payload, dict):
             raise ValueError("Keymap file must contain a JSON object.")
 
@@ -278,6 +435,15 @@ class KeymapManager:
         )
 
         return FileBasedKeymapProvider(keymap_name, merged_leader, merged_action)
+
+    def validate_payload(self, payload: dict) -> None:
+        """Raise ValueError if ``payload`` would fail the loader's checks.
+
+        Called by the in-app editor before writing a proposed edit, so a
+        user-introduced conflict is caught in the UI instead of surfacing
+        as a startup error the next time sqlit launches.
+        """
+        self._build_provider_from_payload(payload, "validation")
 
     # ------------------------------------------------------------------ parsing
 
@@ -525,6 +691,74 @@ class KeymapManager:
                 f"key {key!r} in state {ctx!r} is bound to multiple actions: "
                 f"{sorted(actions)}"
             )
+
+        # Shadow conflicts: the same key bound to *different* actions in
+        # two contexts that share an ancestor/descendant relationship. At
+        # runtime only the most-specific context's binding fires, so the
+        # ancestor binding silently dies in that state — a footgun the
+        # user is rarely intending. Tolerate the case where the same
+        # shadow already exists in defaults (it's an explicit design
+        # choice, not a user mistake).
+        ancestors = _context_ancestors()
+
+        def _related(a: str | None, b: str | None) -> bool:
+            if a is None or b is None or a == b:
+                return False
+            return b in ancestors.get(a, ()) or a in ancestors.get(b, ())
+
+        def _is_default_shadow(ak1: ActionKeyDef, ak2: ActionKeyDef) -> bool:
+            """True if both bindings exist in defaults (so the overlap is
+            intentional and predates the user's edits)."""
+            has1 = any(
+                bk.key == ak1.key and bk.action == ak1.action and bk.context == ak1.context
+                for bk in base_action
+            )
+            has2 = any(
+                bk.key == ak2.key and bk.action == ak2.action and bk.context == ak2.context
+                for bk in base_action
+            )
+            return has1 and has2
+
+        by_key: dict[str, list[ActionKeyDef]] = defaultdict(list)
+        for ak in merged_action:
+            if ak.key:  # skip unbound entries (key="")
+                by_key[ak.key].append(ak)
+
+        user_identities = {(u.action, u.context) for u in user_action}
+        shadow_seen: set[tuple[str, str, str | None, str, str | None]] = set()
+        for key, aks in by_key.items():
+            for i, ak1 in enumerate(aks):
+                for ak2 in aks[i + 1:]:
+                    if ak1.action == ak2.action:
+                        continue
+                    if ak1.context == ak2.context:
+                        continue  # already handled by same-context check
+                    if not _related(ak1.context, ak2.context):
+                        continue
+                    # Only flag if the user's edits introduced the shadow —
+                    # i.e. at least one of the two bindings comes from the
+                    # user, and the same overlap isn't already in defaults.
+                    touched = (
+                        (ak1.action, ak1.context) in user_identities
+                        or (ak2.action, ak2.context) in user_identities
+                    )
+                    if not touched:
+                        continue
+                    if _is_default_shadow(ak1, ak2):
+                        continue
+                    # Dedupe so each conflict shows once.
+                    a, b = sorted(
+                        [(ak1.action, ak1.context), (ak2.action, ak2.context)]
+                    )
+                    sig = (key, a[0], a[1], b[0], b[1])
+                    if sig in shadow_seen:
+                        continue
+                    shadow_seen.add(sig)
+                    conflicts.append(
+                        f"key {key!r} bound to {a[0]!r} in state {a[1]!r} also "
+                        f"matches {b[0]!r} in state {b[1]!r} (ancestor/descendant) — "
+                        f"one binding will silently shadow the other at runtime"
+                    )
 
         if conflicts:
             lines = "\n  - ".join(conflicts)

--- a/sqlit/domains/shell/app/startup_flow.py
+++ b/sqlit/domains/shell/app/startup_flow.py
@@ -170,8 +170,8 @@ def _warn_on_keymap_error(app: AppProtocol, is_headless: bool) -> None:
     error = getattr(manager, "load_error", None) if manager else None
     if not error:
         return
-    from sqlit.domains.shell.app.keymap_manager import CUSTOM_KEYMAP_DIR
-    message = f"{error}\nDefaults are in effect — fix {CUSTOM_KEYMAP_DIR} and restart."
+    from sqlit.domains.shell.app.keymap_manager import DEFAULT_KEYMAP_FILE
+    message = f"{error}\nDefaults are in effect — fix {DEFAULT_KEYMAP_FILE} and restart."
     if is_headless:
         print(f"[sqlit] {message}", file=sys.stderr)
         return

--- a/sqlit/domains/shell/state/main_screen.py
+++ b/sqlit/domains/shell/state/main_screen.py
@@ -10,6 +10,7 @@ class MainScreenState(State):
     """Base state for main screen (no modal active)."""
 
     help_category = "Navigation"
+    keymap_context = "navigation"
 
     def _setup_actions(self) -> None:
         self.allows("focus_explorer", help="Focus Explorer")

--- a/sqlit/domains/shell/state/root.py
+++ b/sqlit/domains/shell/state/root.py
@@ -10,6 +10,7 @@ class RootState(State):
     """Root state - minimal actions available everywhere."""
 
     help_category = "General"
+    keymap_context = "global"
 
     def _setup_actions(self) -> None:
         self.allows("quit", help="Quit")

--- a/sqlit/domains/shell/ui/mixins/ui_leader.py
+++ b/sqlit/domains/shell/ui/mixins/ui_leader.py
@@ -115,6 +115,9 @@ class UILeaderMixin:
     def action_leader_show_help(self: UINavigationMixinHost) -> None:
         self._execute_leader_command("show_help")
 
+    def action_leader_show_keybinding_editor(self: UINavigationMixinHost) -> None:
+        self._execute_leader_command("show_keybinding_editor")
+
     def action_leader_telescope(self: UINavigationMixinHost) -> None:
         self._execute_leader_command("telescope")
 

--- a/sqlit/domains/shell/ui/mixins/ui_navigation.py
+++ b/sqlit/domains/shell/ui/mixins/ui_navigation.py
@@ -181,6 +181,12 @@ class UINavigationMixin(UIStatusMixin, UILeaderMixin):
         help_text = self._state_machine.generate_help_text()
         self.push_screen(HelpScreen(help_text))
 
+    def action_show_keybinding_editor(self: UINavigationMixinHost) -> None:
+        """Open the in-app keybinding editor."""
+        from ..screens import KeybindingEditorScreen
+
+        self.push_screen(KeybindingEditorScreen())
+
     def action_toggle_process_worker(self: UINavigationMixinHost) -> None:
         """Toggle the process worker setting."""
         enabled = not bool(self.services.runtime.process_worker)

--- a/sqlit/domains/shell/ui/screens/__init__.py
+++ b/sqlit/domains/shell/ui/screens/__init__.py
@@ -1,12 +1,16 @@
 """Shell-level modal screens."""
 
 from .help import HelpScreen
+from .key_capture import KeyCaptureScreen
+from .keybinding_editor import KeybindingEditorScreen
 from .leader_menu import LeaderMenuScreen
 from .theme import CustomThemeScreen, ThemeScreen
 
 __all__ = [
     "CustomThemeScreen",
     "HelpScreen",
+    "KeyCaptureScreen",
+    "KeybindingEditorScreen",
     "LeaderMenuScreen",
     "ThemeScreen",
 ]

--- a/sqlit/domains/shell/ui/screens/key_capture.py
+++ b/sqlit/domains/shell/ui/screens/key_capture.py
@@ -1,0 +1,72 @@
+"""Captures the next key press for the in-app keybinding editor."""
+
+from __future__ import annotations
+
+from textual import events
+from textual.app import ComposeResult
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+from sqlit.shared.ui.widgets import Dialog
+
+# Modifier-only key events we want to ignore — the user is mid-chord, not
+# trying to bind "ctrl by itself." Textual emits these as standalone events
+# while the modifier is held before the second key arrives.
+_MODIFIER_ONLY_KEYS = frozenset({"shift", "ctrl", "alt", "meta", "super", "cmd"})
+
+
+class KeyCaptureScreen(ModalScreen[str | None]):
+    """Modal that returns the next pressed key as a Textual key string.
+
+    Dismisses with ``None`` on Escape (cancel), or with the captured key
+    string (e.g. ``"j"``, ``"ctrl+s"``, ``"f5"``) when the user presses
+    something rebindable.
+    """
+
+    CSS = """
+    KeyCaptureScreen {
+        align: center middle;
+        background: transparent;
+    }
+
+    #key-capture-dialog {
+        width: 50;
+        height: auto;
+    }
+
+    #key-capture-message {
+        margin: 1 1;
+        height: auto;
+    }
+    """
+
+    def __init__(self, *, label: str) -> None:
+        super().__init__()
+        self._label = label
+
+    def compose(self) -> ComposeResult:
+        shortcuts = [("Cancel", "<esc>")]
+        with Dialog(id="key-capture-dialog", title="Press a key", shortcuts=shortcuts):
+            yield Static(
+                f"Press a key to bind to:\n  [bold]{self._label}[/]\n\n"
+                "[dim]ESC to cancel.[/]",
+                id="key-capture-message",
+                markup=True,
+            )
+
+    def on_key(self, event: events.Key) -> None:
+        # The user genuinely cannot bind to bare "escape" via this dialog —
+        # we treat ESC as cancel so they can always back out. If they need
+        # to bind escape itself, they can edit keymap.json directly.
+        if event.key == "escape":
+            event.stop()
+            self.dismiss(None)
+            return
+
+        if event.key in _MODIFIER_ONLY_KEYS:
+            # Wait for the actual key — ctrl-by-itself isn't bindable.
+            event.stop()
+            return
+
+        event.stop()
+        self.dismiss(event.key)

--- a/sqlit/domains/shell/ui/screens/keybinding_editor.py
+++ b/sqlit/domains/shell/ui/screens/keybinding_editor.py
@@ -1,0 +1,782 @@
+"""In-app keybinding editor.
+
+Lists every binding from the active keymap (defaults + user overrides),
+lets the user rebind one by pressing a new key, revert one to default,
+or reset every override. Writes flow through
+:class:`sqlit.domains.shell.app.keymap_manager.KeymapManager` so the change
+is persisted to ``~/.config/sqlit/keymap.json`` and applied to the running
+app live — no restart needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+from textual import events
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import OptionList, Static
+from textual.widgets.option_list import Option
+
+from sqlit.core.keymap import (
+    ActionKeyDef,
+    DefaultKeymapProvider,
+    LeaderCommandDef,
+    format_key,
+    get_keymap,
+)
+from sqlit.shared.ui.widgets import Dialog, FilterInput
+
+from .key_capture import KeyCaptureScreen
+
+
+class _NarrowConfirmScreen(ModalScreen[bool | None]):
+    """Small yes/no confirm modal used by the keybinding editor.
+
+    The shared :class:`ConfirmScreen` stretches its dialog to ~80% of the
+    viewport because its inner OptionList has no width cap. Subclassing it
+    and overriding DEFAULT_CSS dropped the centering/transparent-background
+    styles, so this screen redeclares the layout from scratch — same
+    behaviour, tighter footprint.
+    """
+
+    BINDINGS = [
+        Binding("y", "yes", "Yes", show=False),
+        Binding("n", "no", "No", show=False),
+        Binding("escape", "cancel", "Cancel", show=False, priority=True),
+        Binding("enter", "select_option", "Select", show=False),
+    ]
+
+    CSS = """
+    _NarrowConfirmScreen {
+        align: center middle;
+        background: transparent;
+    }
+
+    #narrow-confirm-dialog {
+        width: 44;
+        max-width: 44;
+    }
+
+    #narrow-confirm-description {
+        margin-bottom: 1;
+        color: $text-muted;
+        height: auto;
+    }
+
+    #narrow-confirm-list {
+        height: auto;
+        border: none;
+        width: 100%;
+    }
+
+    #narrow-confirm-list > .option-list--option {
+        padding: 0;
+    }
+    """
+
+    def __init__(self, title: str, description: str | None = None) -> None:
+        super().__init__()
+        self._title = title
+        self._description = description
+
+    def compose(self) -> ComposeResult:
+        shortcuts: list[tuple[str, str]] = [("Yes", "y"), ("No", "n")]
+        with Dialog(id="narrow-confirm-dialog", title=self._title, shortcuts=shortcuts):
+            if self._description:
+                yield Static(
+                    self._description, id="narrow-confirm-description", markup=True
+                )
+            yield OptionList(
+                Option("Yes", id="yes"),
+                Option("No", id="no"),
+                id="narrow-confirm-list",
+            )
+
+    def on_mount(self) -> None:
+        self.query_one("#narrow-confirm-list", OptionList).focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        if event.option.id == "yes":
+            self.dismiss(True)
+        elif event.option.id == "no":
+            self.dismiss(False)
+
+    def action_select_option(self) -> None:
+        ol = self.query_one("#narrow-confirm-list", OptionList)
+        if ol.highlighted is None:
+            return
+        option = ol.get_option_at_index(ol.highlighted)
+        if option.id == "yes":
+            self.dismiss(True)
+        elif option.id == "no":
+            self.dismiss(False)
+
+    def action_yes(self) -> None:
+        self.dismiss(True)
+
+    def action_no(self) -> None:
+        self.dismiss(False)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def check_action(self, action: str, parameters: tuple) -> bool | None:
+        # Don't leak actions to underlying screens while a deeper modal is open.
+        if self.app.screen is not self:
+            return False
+        return super().check_action(action, parameters)
+
+if TYPE_CHECKING:
+    from sqlit.domains.shell.app.main import SSMSTUI
+
+
+# Friendly leader-menu names — the raw IDs ("ry", "rye", "gc") are
+# implementation detail, so spell them out for the editor's section
+# headers. Anything not in here falls back to the menu ID.
+_LEADER_MENU_LABELS: dict[str, str] = {
+    "leader": "Leader (space)",
+    "delete": "Delete operator (d)",
+    "yank": "Yank operator (y)",
+    "change": "Change operator (c)",
+    "g": "g motion",
+    "gc": "gc comment operator",
+    "ry": "Results yank (y)",
+    "rye": "Results export (ye)",
+    "rg": "Results g motion",
+    "vy": "Value-view yank (y)",
+}
+
+# Friendly state names for action_keys section headers — same idea.
+_STATE_LABELS: dict[str, str] = {
+    "global": "Global",
+    "navigation": "Pane navigation",
+    "tree": "Explorer tree",
+    "tree_visual": "Explorer tree (visual)",
+    "tree_filter": "Explorer tree filter",
+    "query_normal": "Query editor (normal)",
+    "query_insert": "Query editor (insert)",
+    "query_visual": "Query editor (visual)",
+    "query_visual_line": "Query editor (visual line)",
+    "autocomplete": "Query editor (autocomplete)",
+    "results": "Results table",
+    "results_filter": "Results filter",
+    "value_view": "Value view",
+    "error_dialog": "Error dialog",
+    "connection_editor": "Connection editor",
+}
+
+
+@dataclass
+class _Row:
+    """One editable binding row in the list."""
+
+    kind: str  # "action" or "leader"
+    scope: str  # state name for action; menu name for leader
+    action: str
+    label: str  # display name for the action
+    current_keys: list[str]  # primary first, then aliases (action) — leader has just one
+    default_keys: list[str]  # what defaults would give
+
+    @property
+    def primary_key(self) -> str:
+        return self.current_keys[0] if self.current_keys else ""
+
+    @property
+    def is_customized(self) -> bool:
+        return self.current_keys != self.default_keys
+
+    @property
+    def identity(self) -> tuple[str, str, str]:
+        """Stable identity for highlight-restoration across rebuilds."""
+        return (self.kind, self.scope, self.action)
+
+
+class KeybindingEditorScreen(ModalScreen):
+    """Modal for editing keybindings in-app.
+
+    Navigation: ``j``/``k`` or arrows. ``enter`` or ``r`` to rebind the
+    highlighted row, ``R`` to revert it to default (with confirmation),
+    ``shift+D`` to reset every override (with confirmation), ``/`` to
+    filter, ``esc`` to close.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Close", priority=True),
+        Binding("enter", "rebind", "Rebind", show=False),
+        Binding("r", "revert", "Revert one", show=False),
+        Binding("R", "reset_all", "Reset all", show=False),
+        Binding("slash", "open_filter", "Filter", show=False),
+        Binding("j", "cursor_down", "Down", show=False),
+        Binding("k", "cursor_up", "Up", show=False),
+    ]
+
+    CSS = """
+    KeybindingEditorScreen {
+        align: center middle;
+        background: transparent;
+    }
+
+    #kb-dialog {
+        width: 90;
+        max-width: 95%;
+        height: 80%;
+        max-height: 90%;
+    }
+
+    #kb-filter {
+        background: $surface;
+    }
+
+    #kb-scroll {
+        height: 1fr;
+        background: $surface;
+        border: none;
+    }
+
+    #kb-list {
+        height: auto;
+        background: $surface;
+        border: none;
+        padding: 0;
+    }
+
+    #kb-list > .option-list--option {
+        padding: 0 1;
+    }
+
+    #kb-empty {
+        text-align: center;
+        color: $text-muted;
+        padding: 2;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Filter state mirrors the QueryHistory pattern: a `/` toggle plus
+        # printable-character buffer driven by on_key, not a focused Input.
+        self._filter_active: bool = False
+        self._filter_text: str = ""
+        self._rows: list[_Row] = []
+        self._visible_rows: list[_Row] = []
+        self._last_highlight_identity: tuple[str, str, str] | None = None
+
+    # ----------------------------------------------------------- compose
+
+    def compose(self) -> ComposeResult:
+        shortcuts = [
+            ("Rebind", "<enter>"),
+            ("Revert", "r"),
+            ("Reset all", "R"),
+        ]
+        with Dialog(id="kb-dialog", title="Edit Keybindings", shortcuts=shortcuts):
+            yield FilterInput(id="kb-filter")
+            with VerticalScroll(id="kb-scroll"):
+                yield OptionList(id="kb-list")
+
+    def on_mount(self) -> None:
+        try:
+            self.query_one("#kb-filter", FilterInput).hide()
+        except Exception:
+            pass
+        self._rebuild_rows()
+        self._render_list()
+        try:
+            option_list = self.query_one("#kb-list", OptionList)
+            option_list.focus()
+            self._move_highlight_to_first_row(option_list)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------- data loading
+
+    def _rebuild_rows(self) -> None:
+        """Build the row list from the current keymap + defaults."""
+        current = get_keymap()
+        defaults = DefaultKeymapProvider()
+
+        # Group action keys by (action, context) so we can list primary+aliases
+        # together. The keymap provider returns primary entries first because
+        # of how DefaultKeymapProvider builds the list; we preserve that.
+        action_index = self._group_action_keys(current.get_action_keys())
+        default_action_index = self._group_action_keys(defaults.get_action_keys())
+
+        leader_index = self._group_leader(current.get_leader_commands())
+        default_leader_index = self._group_leader(defaults.get_leader_commands())
+
+        rows: list[_Row] = []
+
+        # Leader commands first — these are the most discoverable / most
+        # likely to be customized, so they go on top.
+        for (menu, action), cmds in leader_index.items():
+            default_cmds = default_leader_index.get((menu, action), [])
+            current_keys = [c.key for c in cmds]
+            default_keys = [c.key for c in default_cmds]
+            # Use the default command's label as the display text — that's
+            # the human-readable name that lives in the keymap defs.
+            template = default_cmds[0] if default_cmds else cmds[0]
+            rows.append(
+                _Row(
+                    kind="leader",
+                    scope=menu,
+                    action=action,
+                    label=template.label,
+                    current_keys=current_keys,
+                    default_keys=default_keys,
+                )
+            )
+
+        # Then action keys, grouped by state. One row per (action, state).
+        for (state, action), aks in action_index.items():
+            default_aks = default_action_index.get((state, action), [])
+            current_keys = [ak.key for ak in aks]
+            default_keys = [ak.key for ak in default_aks]
+            rows.append(
+                _Row(
+                    kind="action",
+                    scope=state or "global",
+                    action=action,
+                    label=action,
+                    current_keys=current_keys,
+                    default_keys=default_keys,
+                )
+            )
+
+        self._rows = rows
+
+    @staticmethod
+    def _group_action_keys(
+        keys: list[ActionKeyDef],
+    ) -> dict[tuple[str | None, str], list[ActionKeyDef]]:
+        out: dict[tuple[str | None, str], list[ActionKeyDef]] = {}
+        for ak in keys:
+            key_id = (ak.context, ak.action)
+            out.setdefault(key_id, []).append(ak)
+        # Sort: primary first within each (state, action). Stable so the
+        # rest of the order follows declaration order.
+        for v in out.values():
+            v.sort(key=lambda ak: (0 if ak.primary else 1))
+        return out
+
+    @staticmethod
+    def _group_leader(
+        commands: list[LeaderCommandDef],
+    ) -> dict[tuple[str, str], list[LeaderCommandDef]]:
+        out: dict[tuple[str, str], list[LeaderCommandDef]] = {}
+        for cmd in commands:
+            out.setdefault((cmd.menu, cmd.action), []).append(cmd)
+        return out
+
+    # --------------------------------------------------------- rendering
+
+    def _matches_filter(self, row: _Row) -> bool:
+        if not self._filter_text:
+            return True
+        needle = self._filter_text.lower()
+        haystack_parts = [
+            row.action.lower(),
+            row.label.lower(),
+            row.scope.lower(),
+            row.primary_key.lower(),
+            _LEADER_MENU_LABELS.get(row.scope, row.scope).lower()
+            if row.kind == "leader"
+            else _STATE_LABELS.get(row.scope, row.scope).lower(),
+        ]
+        return any(needle in part for part in haystack_parts)
+
+    def _render_list(self) -> None:
+        try:
+            option_list = self.query_one("#kb-list", OptionList)
+        except Exception:
+            return
+
+        # Filter, then group rows by scope. Within each scope we keep the
+        # row's natural order (which preserves the declaration order from
+        # _build_action_keys / _build_leader_commands).
+        leader_rows: dict[str, list[_Row]] = {}
+        action_rows: dict[str, list[_Row]] = {}
+        for row in self._rows:
+            if not self._matches_filter(row):
+                continue
+            bucket = leader_rows if row.kind == "leader" else action_rows
+            bucket.setdefault(row.scope, []).append(row)
+
+        options: list[Option] = []
+        visible: list[_Row] = []
+
+        # Leader sections in a deliberate order — the main "leader" menu
+        # first since that's the only one users typically encounter as a
+        # menu, then the vim-style operators in a sensible reading order.
+        leader_order = ["leader", "delete", "yank", "change", "g", "gc", "ry", "rye", "rg", "vy"]
+        leader_keys_seen: set[str] = set()
+        for menu in leader_order + sorted(leader_rows.keys()):
+            if menu in leader_keys_seen or menu not in leader_rows:
+                continue
+            leader_keys_seen.add(menu)
+            label = _LEADER_MENU_LABELS.get(menu, f"Leader menu: {menu}")
+            options.append(Option(f"── {label} ──", disabled=True))
+            for row in leader_rows[menu]:
+                options.append(self._build_option(row, len(visible)))
+                visible.append(row)
+
+        for state in sorted(action_rows.keys()):
+            label = _STATE_LABELS.get(state, state)
+            options.append(Option(f"── {label} ──", disabled=True))
+            for row in action_rows[state]:
+                options.append(self._build_option(row, len(visible)))
+                visible.append(row)
+
+        option_list.clear_options()
+        if options:
+            option_list.add_options(options)
+        else:
+            option_list.add_option(Option("(no bindings match filter)", disabled=True))
+
+        self._visible_rows = visible
+        self._update_filter_display()
+        self._restore_highlight(option_list)
+
+    def _build_option(self, row: _Row, visible_index: int) -> Option:
+        keys_display = ", ".join(format_key(k) for k in row.current_keys) or "(unbound)"
+        marker = " [yellow]*[/]" if row.is_customized else ""
+        line = (
+            f"  [bold $warning]{keys_display:<14}[/] {row.label}{marker}"
+        )
+        return Option(line, id=f"row-{visible_index}")
+
+    def _move_highlight_to_first_row(self, option_list: OptionList) -> None:
+        for i in range(option_list.option_count):
+            try:
+                opt = option_list.get_option_at_index(i)
+            except Exception:
+                continue
+            if not opt.disabled:
+                option_list.highlighted = i
+                self._last_highlight_identity = (
+                    self._visible_rows[0].identity if self._visible_rows else None
+                )
+                return
+
+    def _restore_highlight(self, option_list: OptionList) -> None:
+        """Try to keep the highlight on the same row after a rebuild.
+
+        After a rebind/revert the row order may stay the same but the
+        OptionList index of a given row can shift (e.g. if filtering
+        changed). Snap back to the same logical row when possible, else
+        fall back to the first selectable row.
+        """
+        if self._last_highlight_identity is not None:
+            for vis_idx, row in enumerate(self._visible_rows):
+                if row.identity == self._last_highlight_identity:
+                    self._highlight_visible(option_list, vis_idx)
+                    return
+        self._move_highlight_to_first_row(option_list)
+
+    def _highlight_visible(self, option_list: OptionList, visible_index: int) -> None:
+        try:
+            target_id = f"row-{visible_index}"
+            option_list.highlighted = option_list.get_option_index(target_id)
+        except Exception:
+            self._move_highlight_to_first_row(option_list)
+
+    # ----------------------------------------------------- highlight helper
+
+    def _current_row(self) -> _Row | None:
+        try:
+            option_list = self.query_one("#kb-list", OptionList)
+        except Exception:
+            return None
+        idx = option_list.highlighted
+        if idx is None:
+            return None
+        try:
+            option = option_list.get_option_at_index(idx)
+        except Exception:
+            return None
+        if option.id is None or not option.id.startswith("row-"):
+            return None
+        try:
+            vis_idx = int(option.id[len("row-") :])
+        except ValueError:
+            return None
+        if 0 <= vis_idx < len(self._visible_rows):
+            return self._visible_rows[vis_idx]
+        return None
+
+    def on_option_list_option_highlighted(
+        self, event: OptionList.OptionHighlighted
+    ) -> None:
+        if event.option_list.id != "kb-list":
+            return
+        row = self._current_row()
+        if row is not None:
+            self._last_highlight_identity = row.identity
+
+    # ---------------------------------------------------------- actions
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    def action_cursor_down(self) -> None:
+        self._move_cursor(+1)
+
+    def action_cursor_up(self) -> None:
+        self._move_cursor(-1)
+
+    def _move_cursor(self, delta: int) -> None:
+        """Step the OptionList highlight by ``delta``, skipping disabled
+        section-header rows so j/k feel native."""
+        try:
+            option_list = self.query_one("#kb-list", OptionList)
+        except Exception:
+            return
+        count = option_list.option_count
+        if count == 0:
+            return
+        idx = option_list.highlighted
+        if idx is None:
+            idx = -1 if delta > 0 else count
+        step = 1 if delta > 0 else -1
+        i = idx + step
+        while 0 <= i < count:
+            try:
+                if not option_list.get_option_at_index(i).disabled:
+                    option_list.highlighted = i
+                    option_list.scroll_to_highlight()
+                    return
+            except Exception:
+                return
+            i += step
+
+    def action_rebind(self) -> None:
+        row = self._current_row()
+        if row is None:
+            return
+        label = f"{row.label}  ({self._scope_label(row)})"
+
+        def on_key(new_key: str | None) -> None:
+            if not new_key:
+                return
+            self._apply_rebind(row, new_key)
+
+        self.app.push_screen(KeyCaptureScreen(label=label), on_key)
+
+    def action_revert(self) -> None:
+        row = self._current_row()
+        if row is None:
+            return
+        if not row.is_customized:
+            self._notify("Already at default", severity="information")
+            return
+
+        title = "Revert this binding?"
+        description = (
+            f"Reset [bold]{row.label}[/] to default "
+            f"({', '.join(format_key(k) for k in row.default_keys) or 'unbound'})?"
+        )
+
+        def on_confirm(result: bool | None) -> None:
+            if not result:
+                return
+            self._apply_revert(row)
+
+        self.app.push_screen(_NarrowConfirmScreen(title, description), on_confirm)
+
+    def action_reset_all(self) -> None:
+        title = "Reset all keybindings?"
+        description = "Wipe all customizations and restore defaults."
+
+        def on_confirm(result: bool | None) -> None:
+            if not result:
+                return
+            self._apply_reset_all()
+
+        self.app.push_screen(_NarrowConfirmScreen(title, description), on_confirm)
+
+    def action_open_filter(self) -> None:
+        self._filter_active = True
+        try:
+            self.query_one("#kb-filter", FilterInput).show()
+        except Exception:
+            pass
+        self._update_filter_display()
+
+    def _close_filter(self) -> None:
+        self._filter_active = False
+        self._filter_text = ""
+        try:
+            self.query_one("#kb-filter", FilterInput).hide()
+        except Exception:
+            pass
+        self._render_list()
+
+    # ------------------------------------------------------ apply / persist
+
+    def _apply_rebind(self, row: _Row, new_key: str) -> None:
+        # Preserve aliases — the merge logic in KeymapManager replaces the
+        # entire key list per (action, state). If we wrote just the new
+        # key we'd silently drop default aliases (e.g. arrow-key aliases
+        # for h/j/k/l), which would surprise the user.
+        manager = self._manager()
+        if manager is None:
+            return
+
+        try:
+            if row.kind == "leader":
+                manager.edit_leader_command(row.scope, row.action, new_key)
+            else:
+                # action_keys: keep existing aliases (everything after the
+                # primary), put the new key first as the new primary.
+                aliases = [k for k in row.current_keys[1:] if k != new_key]
+                key_list: str | list[str] = (
+                    [new_key, *aliases] if aliases else new_key
+                )
+                manager.edit_action_key(row.scope, row.action, key_list)
+        except Exception as exc:
+            self._restore_keymap_after_failure(exc)
+            return
+
+        self._republish_textual_keymap()
+        self._notify(
+            f"Bound {format_key(new_key)} → {row.label}", severity="information"
+        )
+        self._rebuild_rows()
+        self._render_list()
+
+    def _apply_revert(self, row: _Row) -> None:
+        manager = self._manager()
+        if manager is None:
+            return
+        try:
+            if row.kind == "leader":
+                manager.edit_leader_command(row.scope, row.action, None)
+            else:
+                manager.edit_action_key(row.scope, row.action, None)
+        except Exception as exc:
+            self._restore_keymap_after_failure(exc)
+            return
+        self._republish_textual_keymap()
+        self._notify(f"Reverted {row.label}", severity="information")
+        self._rebuild_rows()
+        self._render_list()
+
+    def _apply_reset_all(self) -> None:
+        manager = self._manager()
+        if manager is None:
+            return
+        try:
+            manager.reset_all()
+        except Exception as exc:
+            self._restore_keymap_after_failure(exc)
+            return
+        self._republish_textual_keymap()
+        self._notify("All keybindings reset to defaults", severity="information")
+        self._rebuild_rows()
+        self._render_list()
+
+    def _republish_textual_keymap(self) -> None:
+        """After set_keymap() updates the provider, Textual still needs
+        the new key strings — push them via App.set_keymap so any Binding
+        with an action ID picks them up."""
+        from sqlit.core.keymap import build_textual_keymap, get_keymap as _get
+
+        try:
+            self.app.set_keymap(build_textual_keymap(_get()))
+        except Exception:
+            # Hot-update isn't critical — the next app start will reload
+            # from disk anyway. Don't break the editor flow.
+            pass
+
+    def _restore_keymap_after_failure(self, exc: Exception) -> None:
+        # KeymapManager.validate_payload() raises if the proposed edit
+        # would conflict — the file isn't written, so the user's last
+        # good keymap stays in effect. Surface the full multi-line
+        # message in a modal so the user actually sees it, instead of
+        # a fleeting toast that overlaps the results panel.
+        from sqlit.shared.ui.screens.error import ErrorScreen
+
+        message = str(exc).strip() or "Edit rejected"
+        title = (
+            "Keybinding conflict"
+            if message.lower().startswith("conflicting keybindings")
+            else "Keybinding edit failed"
+        )
+        self.app.push_screen(ErrorScreen(title, message))
+
+    def _manager(self) -> Any:
+        app = cast("SSMSTUI", self.app)
+        manager = getattr(app, "_keymap_manager", None)
+        if manager is None:
+            self._notify(
+                "Keymap manager not available — restart sqlit",
+                severity="error",
+            )
+        return manager
+
+    def _notify(self, message: str, *, severity: str = "information") -> None:
+        try:
+            self.app.notify(message, severity=severity)  # type: ignore[arg-type]
+        except Exception:
+            pass
+
+    def _scope_label(self, row: _Row) -> str:
+        if row.kind == "leader":
+            return _LEADER_MENU_LABELS.get(row.scope, row.scope)
+        return _STATE_LABELS.get(row.scope, row.scope)
+
+    # ---------------------------------------------------------- key handling
+
+    def on_key(self, event: events.Key) -> None:
+        # Only intercept printable characters when filter is open — the
+        # OptionList still owns j/k/arrows for navigation.
+        if not self._filter_active:
+            return
+        key = event.key
+        if key == "escape":
+            self._close_filter()
+            event.stop()
+            return
+        if key == "backspace":
+            if self._filter_text:
+                self._filter_text = self._filter_text[:-1]
+                self._render_list()
+            else:
+                self._close_filter()
+            event.stop()
+            return
+        if event.character and event.character.isprintable():
+            if event.character == "/":
+                # Already inside filter — swallow so it doesn't reopen.
+                event.stop()
+                return
+            self._filter_text += event.character
+            self._render_list()
+            event.stop()
+
+    def _update_filter_display(self) -> None:
+        try:
+            filter_input = self.query_one("#kb-filter", FilterInput)
+        except Exception:
+            return
+        total = len(self._rows)
+        if self._filter_text:
+            filter_input.set_filter(self._filter_text, len(self._visible_rows), total)
+        else:
+            filter_input.set_filter("", 0, total)
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        # Enter on a row triggers a rebind, same as the `r` shortcut.
+        if event.option_list.id != "kb-list":
+            return
+        self.action_rebind()
+
+    def check_action(self, action: str, parameters: tuple) -> bool | None:
+        # Standard guard so underlying screens don't react when a child
+        # modal (KeyCaptureScreen / ConfirmScreen) is on top.
+        if self.app.screen is not self:
+            return False
+        return super().check_action(action, parameters)

--- a/tests/ui/keybindings/test_keymap_manager.py
+++ b/tests/ui/keybindings/test_keymap_manager.py
@@ -31,8 +31,15 @@ def _write(path: Path, payload: dict) -> Path:
 
 
 def _load(tmp_path: Path, name: str, payload: dict) -> KeymapManager:
-    file_path = _write(tmp_path / f"{name}.json", payload)
-    manager = KeymapManager(settings_store=MockSettingsStore({"custom_keymap": str(file_path)}))
+    """Write ``payload`` to the (test-isolated) DEFAULT_KEYMAP_FILE and load it.
+
+    The ``name`` arg is kept for legacy test signatures but no longer maps
+    to a separate file — there's only one keymap file now.
+    """
+    del name  # signature compatibility; single-file model has no named paths
+    from sqlit.domains.shell.app import keymap_manager as km_mod
+    _write(km_mod.DEFAULT_KEYMAP_FILE, payload)
+    manager = KeymapManager(settings_store=MockSettingsStore({}))
     manager.initialize()
     return manager
 
@@ -63,13 +70,16 @@ class TestLifecycle:
         assert manager.load_error is None
         assert get_keymap().action("enter_insert_mode") == "i"
 
-    def test_default_sentinel_uses_scaffold_only(self):
-        manager = KeymapManager(settings_store=MockSettingsStore({"custom_keymap": "default"}))
+    def test_unknown_settings_are_ignored(self):
+        # Legacy `custom_keymap` settings used to switch to a named file.
+        # That mechanism is gone — settings are no longer consulted, so
+        # passing one should be a no-op rather than an error.
+        manager = KeymapManager(settings_store=MockSettingsStore({"custom_keymap": "my-old-name"}))
         manager.initialize()
         assert manager.load_error is None
         assert get_keymap().action("enter_insert_mode") == "i"
 
-    def test_scaffold_created_on_first_run(self, tmp_path_factory):
+    def test_scaffold_created_on_first_run(self):
         # The autouse fixture redirected DEFAULT_KEYMAP_FILE to a fresh tmp dir.
         from sqlit.domains.shell.app import keymap_manager as km_mod
         assert not km_mod.DEFAULT_KEYMAP_FILE.exists()
@@ -78,29 +88,27 @@ class TestLifecycle:
         body = json.loads(km_mod.DEFAULT_KEYMAP_FILE.read_text())
         assert body == {"keymap": {"action_keys": {}, "leader_commands": {}}}
 
-    def test_invalid_json_falls_back(self, tmp_path: Path):
-        path = tmp_path / "invalid.json"
-        path.write_text("not valid json", encoding="utf-8")
-        manager = KeymapManager(settings_store=MockSettingsStore({"custom_keymap": str(path)}))
+    def test_invalid_json_falls_back(self):
+        from sqlit.domains.shell.app import keymap_manager as km_mod
+        km_mod.DEFAULT_KEYMAP_FILE.parent.mkdir(parents=True, exist_ok=True)
+        km_mod.DEFAULT_KEYMAP_FILE.write_text("not valid json", encoding="utf-8")
+        manager = KeymapManager(settings_store=MockSettingsStore({}))
         manager.initialize()
-        assert manager.load_error and "Failed to load custom keymap" in manager.load_error
+        assert manager.load_error and "Failed to load" in manager.load_error
         assert not isinstance(get_keymap(), FileBasedKeymapProvider)
 
-    def test_missing_file_falls_back(self, tmp_path: Path):
-        manager = KeymapManager(
-            settings_store=MockSettingsStore({"custom_keymap": str(tmp_path / "nope.json")})
-        )
-        manager.initialize()
-        assert manager.load_error and "not found" in manager.load_error
-
-    def test_load_error_cleared_on_clean_reinit(self, tmp_path: Path):
-        path = tmp_path / "bad.json"
-        path.write_text("not valid json", encoding="utf-8")
-        manager = KeymapManager(settings_store=MockSettingsStore({"custom_keymap": str(path)}))
+    def test_load_error_cleared_on_clean_reinit(self):
+        from sqlit.domains.shell.app import keymap_manager as km_mod
+        km_mod.DEFAULT_KEYMAP_FILE.parent.mkdir(parents=True, exist_ok=True)
+        km_mod.DEFAULT_KEYMAP_FILE.write_text("not valid json", encoding="utf-8")
+        manager = KeymapManager(settings_store=MockSettingsStore({}))
         manager.initialize()
         assert manager.load_error is not None
-        # Re-running with the default sentinel must clear the prior error.
-        manager._settings_store = MockSettingsStore({"custom_keymap": "default"})  # type: ignore[attr-defined]
+        # Replace the bad file with a clean scaffold — next init must clear the error.
+        km_mod.DEFAULT_KEYMAP_FILE.write_text(
+            json.dumps({"keymap": {"action_keys": {}, "leader_commands": {}}}),
+            encoding="utf-8",
+        )
         manager.initialize()
         assert manager.load_error is None
 
@@ -227,23 +235,6 @@ class TestDefaultKeymapFile:
         manager.initialize()
         assert manager.load_error is None
         assert get_keymap().action("execute_query") == "ctrl+enter"
-
-    def test_settings_override_takes_precedence(self, tmp_path: Path, monkeypatch):
-        # If both default file and `custom_keymap` setting exist, the setting wins.
-        from sqlit.domains.shell.app import keymap_manager as km_mod
-        default_path = tmp_path / "keymap.json"
-        default_path.write_text(json.dumps(
-            {"keymap": {"action_keys": {"query_normal": {"execute_query": "ctrl+enter"}}}}
-        ))
-        monkeypatch.setattr(km_mod, "DEFAULT_KEYMAP_FILE", default_path)
-
-        named = tmp_path / "named.json"
-        named.write_text(json.dumps(
-            {"keymap": {"action_keys": {"query_normal": {"execute_query": "ctrl+shift+enter"}}}}
-        ))
-        manager = KeymapManager(settings_store=MockSettingsStore({"custom_keymap": str(named)}))
-        manager.initialize()
-        assert get_keymap().action("execute_query") == "ctrl+shift+enter"
 
     def test_no_setting_creates_scaffold_and_loads_it(self, tmp_path: Path, monkeypatch):
         from sqlit.domains.shell.app import keymap_manager as km_mod
@@ -457,16 +448,52 @@ class TestConflicts:
         )
         assert manager.load_error is None
 
+    def test_ancestor_shadow_is_caught(self, tmp_path: Path):
+        # Default: '?' → show_help in 'global'. Binding '?' in
+        # 'query_normal' to a different action shadows show_help at
+        # runtime (descendant context wins). Must be flagged so the user
+        # discovers it in the UI, not via the silent loss of '?' help in
+        # the query editor.
+        manager = _load(
+            tmp_path,
+            "shadow",
+            {"keymap": {"action_keys": {"query_normal": {"enter_insert_mode": "?"}}}},
+        )
+        assert manager.load_error is not None
+        assert "shadow" in manager.load_error.lower()
+        assert "question_mark" in manager.load_error
+        assert "query_normal" in manager.load_error
+        assert "global" in manager.load_error
+
+    def test_sibling_contexts_do_not_shadow(self, tmp_path: Path):
+        # 'tree' and 'query_normal' are sibling pane-focused contexts —
+        # only one is active at a time, so binding the same key to
+        # different actions across them is fine.
+        manager = _load(
+            tmp_path,
+            "siblings",
+            {
+                "keymap": {
+                    "action_keys": {
+                        # `ctrl+e` is unused in defaults across both states.
+                        "query_normal": {"cursor_word_end": "ctrl+e"},
+                    }
+                }
+            },
+        )
+        assert manager.load_error is None
+
 
 class TestStartupNotification:
     """The load error is surfaced to the user via app.notify on startup."""
 
-    def test_notifies_when_load_error_present(self, tmp_path: Path):
+    def test_notifies_when_load_error_present(self):
         from sqlit.domains.shell.app.startup_flow import _warn_on_keymap_error
+        from sqlit.domains.shell.app import keymap_manager as km_mod
 
-        path = tmp_path / "bad.json"
-        path.write_text("not valid json", encoding="utf-8")
-        manager = KeymapManager(settings_store=MockSettingsStore({"custom_keymap": str(path)}))
+        km_mod.DEFAULT_KEYMAP_FILE.parent.mkdir(parents=True, exist_ok=True)
+        km_mod.DEFAULT_KEYMAP_FILE.write_text("not valid json", encoding="utf-8")
+        manager = KeymapManager(settings_store=MockSettingsStore({}))
         manager.initialize()
         assert manager.load_error is not None
 
@@ -490,7 +517,7 @@ class TestStartupNotification:
         assert len(notifications) == 1
         severity, message = notifications[0]
         assert severity == "error"
-        assert "Failed to load custom keymap" in message
+        assert "Failed to load" in message
         assert "Defaults are in effect" in message
 
     def test_silent_when_no_load_error(self, tmp_path: Path):


### PR DESCRIPTION
Adds an in-app keybinding editor accessible via `<space>k`. Lists every binding (default or user-overridden), lets you rebind by pressing a new key, revert one to default, or wipe all overrides. Edits write to `~/.config/sqlit/keymap.json` and apply live — no restart.

Two additional cleanups bundled in because the editor exposed both:
- Drops the `custom_keymap` named-keymap setting and `~/.config/sqlit/keymaps/` directory. There's one keymap file now (auto-scaffolded), which makes the editor's write path unambiguous.
- Conflict detection now catches **ancestor shadows** — e.g. binding `?` in `query_normal` would silently shadow the global `show_help`. The detector walks the same `State.parent` chain the runtime resolver uses (each `State` subclass now carries a `keymap_context` class attribute), so there's no parallel hierarchy table.