### PR TITLE
Fix delete/update shortcuts for markup-rendered result cells

### DIFF
--- a/sqlit/domains/results/ui/mixins/results.py
+++ b/sqlit/domains/results/ui/mixins/results.py
@@ -813,7 +813,9 @@ class ResultsMixin:
 
         try:
             cursor_row, _cursor_col = table.cursor_coordinate
-            row_values = table.get_row_at(cursor_row)
+            row_values = [
+                _strip_table_markup(table, v) for v in table.get_row_at(cursor_row)
+            ]
         except Exception:
             return
 
@@ -895,7 +897,9 @@ class ResultsMixin:
 
         try:
             cursor_row, cursor_col = table.cursor_coordinate
-            row_values = table.get_row_at(cursor_row)
+            row_values = [
+                _strip_table_markup(table, v) for v in table.get_row_at(cursor_row)
+            ]
         except Exception:
             return
 

--- a/tests/unit/test_results_copy_markup.py
+++ b/tests/unit/test_results_copy_markup.py
@@ -85,3 +85,47 @@ def test_copy_cell_preserves_literal_brackets_when_not_rendering_markup() -> Non
     app = _FakeApp([("[bold]hello",)], render_markup=False)
     app.action_copy_cell()
     assert app.clipboard_text == "[bold]hello"
+
+class _FakeQueryInput:
+    def __init__(self) -> None:
+        self.text = ""
+        self.cursor_location = (0, 0)
+        self.read_only = True
+
+    def focus(self) -> None:
+        pass
+
+
+class _FakeEditApp(_FakeApp):
+    def __init__(self, cells: list[tuple[str, ...]], columns: list[str]) -> None:
+        super().__init__(cells, render_markup=True)
+        self._columns = columns
+        self.query_input = _FakeQueryInput()
+        self._suppress_autocomplete_once = False
+
+    def _get_active_results_context(self) -> tuple[Any, list, list, bool]:
+        return self._table, self._columns, [], False
+
+    def _get_active_results_table_info(self, _table: Any, _stacked: bool) -> dict[str, Any]:
+        return {"name": "users", "columns": []}
+
+    def action_focus_query(self) -> None:
+        pass
+
+    def _update_footer_bindings(self) -> None:
+        pass
+
+    def _update_vim_mode_visuals(self) -> None:
+        pass
+
+
+def test_delete_row_strips_filter_markup_before_generating_sql() -> None:
+    app = _FakeEditApp([("[bold #FFFF00]Ja[/]ne",)], ["name"])
+    app.action_delete_row()
+    assert app.query_input.text == "DELETE FROM users WHERE name = 'Jane';"
+
+
+def test_edit_cell_strips_filter_markup_before_generating_sql() -> None:
+    app = _FakeEditApp([("[bold #FFFF00]Ja[/]ne",)], ["name"])
+    app.action_edit_cell()
+    assert "WHERE name = 'Jane';" in app.query_input.text


### PR DESCRIPTION
## Summary

This PR strips Rich markup from result table values before using them for `DELETE` / `UPDATE` actions from the result view.

The copy-related case has already been fixed, but I noticed that the same markup could still be included when generating `DELETE` or `UPDATE` statements from the result view, so this PR addresses that remaining case.

## Notes

I tested this with MySQL.

## Related issue

Fixes #229


### example

<img width="249" height="98" alt="スクリーンショット 2026-05-25 18 22 14" src="https://github.com/user-attachments/assets/19366344-a123-4e89-ad78-2fc0d3c59b22" />

```
DELETE FROM users WHERE id = '[bold #FFFF00]1[/]';
UPDATE users SET name = '' WHERE id = '[bold #FFFF00]1[/]';
```