### PR TITLE
add sqlit-tui command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ max-complexity = 25  # complex domain logic in cloud providers and TUI screens
 
 [project.scripts]
 sqlit = "sqlit.cli:main"
+sqlit-tui = "sqlit.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/Maxteabag/sqlit"


### PR DESCRIPTION
This PR adds a `sqlit-tui` command to the ist of entry points. This makes it easier to use `sqlit` with `uvx`. Because sqlit uses two distinct names for it's CLI (`sqlit`) and its package name (`sqlit-tui`), a user has to call it using `uvx` like

```
uvx --from sqlit-tui sqlit
```

and after this change this can be simplified to just

```
uvx sqlit-tui
```