### PR TITLE
feat: add hotkey for DROP TABLE query generation

### DIFF
--- a/config/keymap.template.json
+++ b/config/keymap.template.json
@@ -22,6 +22,7 @@
         "enter_tree_visual_mode": "v",
         "clear_connection_selection": "escape",
         "select_table": "s",
+        "drop_table": "d",
         "refresh_tree": [
           "f",
           "R"

--- a/sqlit/core/input_context.py
+++ b/sqlit/core/input_context.py
@@ -34,3 +34,4 @@ class InputContext:
     has_results: bool
     stacked_result_count: int = 0
     count_buffer: str = ""
+    current_provider_supports_drop_table: bool = False

--- a/sqlit/core/keymap.py
+++ b/sqlit/core/keymap.py
@@ -347,6 +347,7 @@ class DefaultKeymapProvider(KeymapProvider):
             ActionKeyDef("d", "delete_connection_folder", "tree"),
             ActionKeyDef("delete", "delete_connection_folder", "tree", primary=False),
             ActionKeyDef("d", "delete_connection", "tree"),
+            ActionKeyDef("d", "drop_table", "tree"),
             ActionKeyDef("delete", "delete_connection", "tree", primary=False),
             ActionKeyDef("D", "duplicate_connection", "tree"),
             ActionKeyDef("m", "move_connection_to_folder", "tree"),

--- a/sqlit/domains/connections/providers/adapter_provider.py
+++ b/sqlit/domains/connections/providers/adapter_provider.py
@@ -90,6 +90,7 @@ def build_adapter_provider(spec: ProviderSpec, schema: ConnectionSchema, adapter
         supports_indexes=bool(getattr(adapter, "supports_indexes", False)),
         supports_triggers=bool(getattr(adapter, "supports_triggers", False)),
         supports_sequences=bool(getattr(adapter, "supports_sequences", False)),
+        support_drop_table=(bool(getattr(adapter, "supports_drop_table", False))),
         default_schema=str(getattr(adapter, "default_schema", "")),
         system_databases=frozenset(getattr(adapter, "system_databases", frozenset())),
     )

--- a/sqlit/domains/connections/providers/adapters/base.py
+++ b/sqlit/domains/connections/providers/adapters/base.py
@@ -200,6 +200,10 @@ class DatabaseAdapter(ABC):
         return True
 
     @property
+    def supports_drop_table(self) -> bool:
+        return True
+
+    @property
     def test_query(self) -> str:
         """A simple query to test the connection.
 
@@ -440,6 +444,17 @@ class DatabaseAdapter(ABC):
         Args:
             table: Table name.
             limit: Maximum rows to return.
+            database: Database name (if supported).
+            schema: Schema name (if supported).
+        """
+        pass
+
+    @abstractmethod
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build a SELECT query with limit.
+
+        Args:
+            table: Table name.
             database: Database name (if supported).
             schema: Schema name (if supported).
         """

--- a/sqlit/domains/connections/providers/athena/adapter.py
+++ b/sqlit/domains/connections/providers/athena/adapter.py
@@ -149,6 +149,10 @@ class AthenaAdapter(CursorBasedAdapter):
         target_db = database or schema or self.default_schema
         return f"SELECT * FROM {target_db}.{table} LIMIT {limit}"
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        return f'DROP TABLE IF EXISTS "{database or ""}.{table}"'
+
     def get_procedures(self, conn: Any, database: str | None = None) -> list[str]:
         return []
 

--- a/sqlit/domains/connections/providers/bigquery/adapter.py
+++ b/sqlit/domains/connections/providers/bigquery/adapter.py
@@ -375,3 +375,8 @@ class BigQueryAdapter(CursorBasedAdapter):
                 return f"SELECT * FROM `{dataset}.{table}` LIMIT {limit}"
             return f"SELECT * FROM `{dataset}`.`{table}` LIMIT {limit}"
         return f"SELECT * FROM `{table}` LIMIT {limit}"
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        dataset = schema or database
+        return f"DROP TABLE IF EXISTS `{dataset}.{table}`"

--- a/sqlit/domains/connections/providers/clickhouse/adapter.py
+++ b/sqlit/domains/connections/providers/clickhouse/adapter.py
@@ -296,6 +296,15 @@ class ClickHouseAdapter(DatabaseAdapter):
             return f"SELECT * FROM {quoted_db}.{quoted_table} LIMIT {limit}"
         return f"SELECT * FROM {quoted_table} LIMIT {limit}"
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        db = database or schema
+        quoted_table = self.quote_identifier(table)
+        if db:
+            quoted_db = self.quote_identifier(db)
+            return f"DROP TABLE IF EXISTS {quoted_db}.{quoted_table}"
+        return f"DROP TABLE IF EXISTS {quoted_table}"
+
     def execute_query(
         self, conn: Any, query: str, max_rows: int | None = None
     ) -> tuple[list[str], list[tuple], bool]:

--- a/sqlit/domains/connections/providers/d1/adapter.py
+++ b/sqlit/domains/connections/providers/d1/adapter.py
@@ -269,6 +269,10 @@ class D1Adapter(DatabaseAdapter):
         """Builds a standard SELECT ... LIMIT query."""
         return f"SELECT * FROM {self.quote_identifier(table)} LIMIT {limit}"
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        return f"DROP TABLE IF EXISTS {self.quote_identifier(table)}"
+
     def execute_query(
         self, conn: D1Connection, query: str, max_rows: int | None = None
     ) -> tuple[list[str], list[tuple], bool]:

--- a/sqlit/domains/connections/providers/db2/adapter.py
+++ b/sqlit/domains/connections/providers/db2/adapter.py
@@ -190,3 +190,8 @@ class Db2Adapter(CursorBasedAdapter):
         if schema:
             return f'SELECT * FROM "{schema}"."{table}" FETCH FIRST {limit} ROWS ONLY'
         return f'SELECT * FROM "{table}" FETCH FIRST {limit} ROWS ONLY'
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        schema = schema or ""
+        return f'DROP TABLE "{schema}"."{table}"' if schema else f'DROP TABLE "{table}"'

--- a/sqlit/domains/connections/providers/duckdb/adapter.py
+++ b/sqlit/domains/connections/providers/duckdb/adapter.py
@@ -275,6 +275,10 @@ class DuckDBAdapter(DatabaseAdapter):
         schema = schema or "main"
         return f'SELECT * FROM "{schema}"."{table}" LIMIT {limit}'
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        schema = schema or "main"
+        return f'DROP TABLE IF EXISTS "{schema}"."{table}"'
+
     def execute_query(self, conn: Any, query: str, max_rows: int | None = None) -> tuple[list[str], list[tuple], bool]:
         """Execute a query on DuckDB with optional row limit."""
         result = conn.execute(query)

--- a/sqlit/domains/connections/providers/firebird/adapter.py
+++ b/sqlit/domains/connections/providers/firebird/adapter.py
@@ -347,6 +347,10 @@ class FirebirdAdapter(CursorBasedAdapter):
         """Build SELECT LIMIT query."""
         return f'SELECT * FROM "{table}" ROWS {limit}'
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        return f'DROP TABLE "{table}"'
+
     def execute_non_query(self, conn: Any, query: str) -> int:
         # Firebird has no autocommit mode, so we need to guarantee it ourselves.
         try:

--- a/sqlit/domains/connections/providers/flight/adapter.py
+++ b/sqlit/domains/connections/providers/flight/adapter.py
@@ -358,6 +358,14 @@ class FlightSQLAdapter(DatabaseAdapter):
             return f"SELECT * FROM {quoted_schema}.{quoted_table} LIMIT {limit}"
         return f"SELECT * FROM {quoted_table} LIMIT {limit}"
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        quoted_table = self.quote_identifier(table)
+        if schema:
+            quoted_schema = self.quote_identifier(schema)
+            return f'DROP TABLE IF EXISTS {quoted_schema}.{quoted_table}'
+        return f'DROP TABLE IF EXISTS {quoted_table}'
+
     def _arrow_table_to_tuples(
         self, table: Any
     ) -> tuple[list[str], list[tuple[Any, ...]]]:

--- a/sqlit/domains/connections/providers/hana/adapter.py
+++ b/sqlit/domains/connections/providers/hana/adapter.py
@@ -183,3 +183,8 @@ class HanaAdapter(CursorBasedAdapter):
     def build_select_query(self, table: str, limit: int, database: str | None = None, schema: str | None = None) -> str:
         schema = schema or self.default_schema
         return f'SELECT * FROM "{schema}"."{table}" LIMIT {limit}'
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        schema = schema or self.default_schema
+        return f'DROP TABLE "{schema}"."{table}"'

--- a/sqlit/domains/connections/providers/impala/adapter.py
+++ b/sqlit/domains/connections/providers/impala/adapter.py
@@ -174,3 +174,6 @@ class ImpalaAdapter(CursorBasedAdapter):
         if database:
             return f"SELECT * FROM `{database}`.`{table}` LIMIT {limit}"
         return f"SELECT * FROM `{table}` LIMIT {limit}"
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        return f"DROP TABLE IF EXISTS `{database}`.`{table}`" if database else f"DROP TABLE IF EXISTS `{table}`"

--- a/sqlit/domains/connections/providers/model.py
+++ b/sqlit/domains/connections/providers/model.py
@@ -36,6 +36,7 @@ class SchemaCapabilities:
     supports_indexes: bool
     supports_triggers: bool
     supports_sequences: bool
+    support_drop_table: bool
     default_schema: str
     system_databases: frozenset[str]
 
@@ -58,6 +59,9 @@ class Dialect(Protocol):
     def quote_identifier(self, name: str) -> str: ...
 
     def build_select_query(self, table: str, limit: int, database: str | None = None, schema: str | None = None) -> str:
+        ...
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
         ...
 
     def format_table_name(self, schema: str | None, table: str) -> str: ...

--- a/sqlit/domains/connections/providers/mssql/adapter.py
+++ b/sqlit/domains/connections/providers/mssql/adapter.py
@@ -545,6 +545,11 @@ class SQLServerAdapter(DatabaseAdapter):
         schema = schema or "dbo"
         return f"SELECT TOP {limit} * FROM [{schema}].[{table}]"
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        schema = schema or "dbo"
+        return f'DROP TABLE IF EXISTS [{schema}].[{table}]'
+
     def execute_query(self, conn: Any, query: str, max_rows: int | None = None) -> tuple[list[str], list[tuple], bool]:
         """Execute a query on SQL Server with optional row limit."""
         cursor = conn.cursor()

--- a/sqlit/domains/connections/providers/mysql/base.py
+++ b/sqlit/domains/connections/providers/mysql/base.py
@@ -148,6 +148,12 @@ class MySQLBaseAdapter(CursorBasedAdapter):
             return f"SELECT * FROM `{database}`.`{table}` LIMIT {limit}"
         return f"SELECT * FROM `{table}` LIMIT {limit}"
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        db = database or schema
+        return f"DROP TABLE IF EXISTS `{db}`.`{table}`" if db else f"DROP TABLE IF EXISTS `{table}`"
+
+
     def get_indexes(self, conn: Any, database: str | None = None) -> list[IndexInfo]:
         """Get indexes from MySQL/MariaDB."""
         cursor = conn.cursor()

--- a/sqlit/domains/connections/providers/oracle/adapter.py
+++ b/sqlit/domains/connections/providers/oracle/adapter.py
@@ -335,6 +335,10 @@ class OracleAdapter(DatabaseAdapter):
         """Build SELECT query with FETCH FIRST for Oracle 12c+. Schema parameter is ignored."""
         return f'SELECT * FROM "{table}" FETCH FIRST {limit} ROWS ONLY'
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        return f'DROP TABLE "{table}"'
+
     def execute_query(self, conn: Any, query: str, max_rows: int | None = None) -> tuple[list[str], list[tuple], bool]:
         """Execute a query on Oracle with optional row limit."""
         cursor = conn.cursor()

--- a/sqlit/domains/connections/providers/osquery/adapter.py
+++ b/sqlit/domains/connections/providers/osquery/adapter.py
@@ -94,6 +94,10 @@ class OsqueryAdapter(DatabaseAdapter):
         return False
 
     @property
+    def supports_drop_table(self) -> bool:
+        return False
+
+    @property
     def default_schema(self) -> str:
         return ""
 
@@ -198,6 +202,10 @@ class OsqueryAdapter(DatabaseAdapter):
         self, table: str, limit: int, database: str | None = None, schema: str | None = None
     ) -> str:
         return f'SELECT * FROM "{table}" LIMIT {limit}'
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        return ''
 
     def execute_query(
         self, conn: Any, query: str, max_rows: int | None = None

--- a/sqlit/domains/connections/providers/postgresql/base.py
+++ b/sqlit/domains/connections/providers/postgresql/base.py
@@ -124,6 +124,11 @@ class PostgresBaseAdapter(CursorBasedAdapter):
         schema = schema or "public"
         return f'SELECT * FROM "{schema}"."{table}" LIMIT {limit}'
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        schema = schema or "public"
+        return f'DROP TABLE IF EXISTS "{schema}"."{table}"'
+
     @property
     def supports_sequences(self) -> bool:
         """PostgreSQL supports sequences."""

--- a/sqlit/domains/connections/providers/presto/adapter.py
+++ b/sqlit/domains/connections/providers/presto/adapter.py
@@ -190,3 +190,11 @@ class PrestoAdapter(CursorBasedAdapter):
         if schema_name:
             return f'SELECT * FROM "{schema_name}"."{table}" LIMIT {limit}'
         return f'SELECT * FROM "{table}" LIMIT {limit}'
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        schema_name = schema or self.default_schema
+        if database and schema_name:
+            return f'DROP TABLE IF EXISTS "{database}"."{schema_name}"."{table}"'
+        if db := database or schema:
+            return f'DROP TABLE IF EXISTS "{db}"."{table}"'
+        return f'DROP TABLE IF EXISTS "{table}"'

--- a/sqlit/domains/connections/providers/redshift/adapter.py
+++ b/sqlit/domains/connections/providers/redshift/adapter.py
@@ -233,3 +233,8 @@ class RedshiftAdapter(CursorBasedAdapter):
         """Build SELECT query with LIMIT."""
         schema = schema or self.default_schema
         return f'SELECT * FROM "{schema}"."{table}" LIMIT {limit}'
+
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        schema = schema or self.default_schema
+        return f'DROP TABLE IF EXISTS "{schema}"."{table}"'

--- a/sqlit/domains/connections/providers/snowflake/adapter.py
+++ b/sqlit/domains/connections/providers/snowflake/adapter.py
@@ -199,6 +199,11 @@ class SnowflakeAdapter(CursorBasedAdapter):
         schema = schema or "PUBLIC"
         return f'SELECT * FROM "{schema}"."{table}" LIMIT {limit}'
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        schema = schema or "PUBLIC"
+        return f'DROP TABLE IF EXISTS "{schema}"."{table}"'
+
     def get_procedures(self, conn: Any, database: str | None = None) -> list[str]:
         """Get stored procedures."""
         cursor = conn.cursor()

--- a/sqlit/domains/connections/providers/spanner/adapter.py
+++ b/sqlit/domains/connections/providers/spanner/adapter.py
@@ -376,3 +376,8 @@ class SpannerAdapter(CursorBasedAdapter):
         """Build SELECT query with LIMIT using connection-aware quoting."""
         quoted = self._quote_identifier_for_conn(conn, table)
         return f"SELECT * FROM {quoted} LIMIT {limit}"
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        quoted_table = self._quote_identifier_for_dialect(DIALECT_GOOGLESQL, table)
+        return f'DROP TABLE IF EXISTS {quoted_table}'

--- a/sqlit/domains/connections/providers/sqlite/adapter.py
+++ b/sqlit/domains/connections/providers/sqlite/adapter.py
@@ -206,6 +206,10 @@ class SQLiteAdapter(DatabaseAdapter):
         """Build SELECT LIMIT query for SQLite. Schema parameter is ignored."""
         return f'SELECT * FROM "{table}" LIMIT {limit}'
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        return f"DROP TABLE IF EXISTS {table}"
+
     def execute_query(self, conn: Any, query: str, max_rows: int | None = None) -> tuple[list[str], list[tuple], bool]:
         """Execute a query on SQLite with optional row limit."""
         cursor = conn.cursor()

--- a/sqlit/domains/connections/providers/surrealdb/adapter.py
+++ b/sqlit/domains/connections/providers/surrealdb/adapter.py
@@ -245,6 +245,10 @@ class SurrealDBAdapter(DatabaseAdapter):
     ) -> str:
         return f"SELECT * FROM {self.quote_identifier(table)} LIMIT {limit}"
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build REMOVE TABLE query."""
+        return f"REMOVE TABLE {self.quote_identifier(table)}"
+
     def execute_query(
         self, conn: Any, query: str, max_rows: int | None = None
     ) -> tuple[list[str], list[tuple], bool]:

--- a/sqlit/domains/connections/providers/teradata/adapter.py
+++ b/sqlit/domains/connections/providers/teradata/adapter.py
@@ -264,3 +264,7 @@ class TeradataAdapter(CursorBasedAdapter):
         if schema_name:
             return f'lock row for access select top {limit} * from "{schema_name}"."{table}"'
         return f'lock row for access select top {limit} * from "{table}"'
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        db = database or schema
+        return f'DROP TABLE "{db}"."{table}"' if db else f'DROP TABLE "{table}"'

--- a/sqlit/domains/connections/providers/trino/adapter.py
+++ b/sqlit/domains/connections/providers/trino/adapter.py
@@ -190,3 +190,12 @@ class TrinoAdapter(CursorBasedAdapter):
         if schema_name:
             return f'SELECT * FROM "{schema_name}"."{table}" LIMIT {limit}'
         return f'SELECT * FROM "{table}" LIMIT {limit}'
+
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        schema_name = schema or self.default_schema
+        if database and schema_name:
+            return f'DROP TABLE IF EXISTS "{database}"."{schema_name}"."{table}"'
+        if db := database or schema_name:
+            return f'DROP TABLE IF EXISTS "{db}"."{table}"'
+        return f'DROP TABLE IF EXISTS "{table}"'

--- a/sqlit/domains/connections/providers/turso/adapter.py
+++ b/sqlit/domains/connections/providers/turso/adapter.py
@@ -176,6 +176,10 @@ class TursoAdapter(DatabaseAdapter):
         """Build SELECT LIMIT query for Turso. Schema parameter is ignored."""
         return f'SELECT * FROM "{table}" LIMIT {limit}'
 
+    def build_drop_table_query(self, table: str, database: str | None = None, schema: str | None = None) -> str:
+        """Build DROP TABLE query."""
+        return f'DROP TABLE IF EXISTS "{table}"'
+
     def execute_query(self, conn: Any, query: str, max_rows: int | None = None) -> tuple[list[str], list[tuple], bool]:
         """Execute a query on Turso with optional row limit."""
         cur = conn.cursor()

--- a/sqlit/domains/explorer/state/tree_on_table.py
+++ b/sqlit/domains/explorer/state/tree_on_table.py
@@ -13,6 +13,12 @@ class TreeOnTableState(State):
 
     def _setup_actions(self) -> None:
         self.allows("select_table", label="Select TOP 100", help="Select TOP 100 (table/view)")
+        self.allows(
+            "drop_table",
+            guard=lambda app: app.tree_node_kind == "table" and app.current_provider_supports_drop_table,
+            label="Drop Table",
+            help="Drop selected Table",
+        )
 
     def get_display_bindings(self, app: InputContext) -> tuple[list[DisplayBinding], list[DisplayBinding]]:
         left: list[DisplayBinding] = []
@@ -28,6 +34,15 @@ class TreeOnTableState(State):
             )
         )
         seen.add("select_table")
+        if app.tree_node_kind == "table" and app.current_provider_supports_drop_table:
+            left.append(
+                DisplayBinding(
+                    key=resolve_display_key("drop_table") or "d",
+                    label="Drop Table",
+                    action="drop_table",
+                )
+            )
+            seen.add("drop_table")
         left.append(
             DisplayBinding(
                 key=resolve_display_key("refresh_tree") or "f",

--- a/sqlit/domains/explorer/ui/mixins/tree.py
+++ b/sqlit/domains/explorer/ui/mixins/tree.py
@@ -357,6 +357,38 @@ class TreeMixin(TreeSchemaMixin, TreeLabelMixin):
             tree_object_info.show_sequence_info(self, data)
             return
 
+    def action_drop_table(self: TreeMixinHost) -> None:
+        """Generate DROP TABLE query for selected table."""
+        if not self.current_provider or not self._session:
+            return
+
+        if not self.current_provider.capabilities.support_drop_table:
+            return
+
+        node = self.object_tree.cursor_node
+
+        if not node or not node.data:
+            return
+
+        data = node.data
+
+        if self._get_node_kind(node) == "table":
+            self._last_query_table = {
+                "database": data.database,
+                "schema": data.schema,
+                "name": data.name,
+                "columns": [],
+            }
+
+            self.query_input.text = self.current_provider.dialect.build_drop_table_query(
+                data.name,
+                data.database,
+                data.schema,
+            )
+            self._query_target_database = data.database
+            self.query_input.focus()
+            return
+
     def action_use_database(self: TreeMixinHost) -> None:
         """Toggle the selected database as the default for the current connection."""
         node = self.object_tree.cursor_node

--- a/sqlit/domains/shell/app/main.py
+++ b/sqlit/domains/shell/app/main.py
@@ -319,6 +319,9 @@ class SSMSTUI(
             has_results=has_results,
             stacked_result_count=stacked_result_count,
             count_buffer=self._count_buffer,
+            current_provider_supports_drop_table=bool(
+                self.current_provider and self.current_provider.capabilities.support_drop_table
+            ),
         )
 
     def _debug_screen_label(self, screen: Any | None) -> str:

--- a/sqlit/domains/shell/state/machine.py
+++ b/sqlit/domains/shell/state/machine.py
@@ -214,6 +214,7 @@ class UIStateMachine:
         s.binding("<enter>", "Expand node / Connect")
         s.binding(k("new_connection", "n"), "New connection")
         s.binding(k("select_table", "s"), "SELECT TOP 100 (on table/view)")
+        s.binding(k("drop_table", "d"), "DROP TABLE (if supported by the database)")
         s.binding(k("tree_filter", "/"), "Filter tree")
         s.binding(k("collapse_tree", "z"), "Collapse all nodes")
         s.binding(k("refresh_tree", "f"), "Refresh tree")


### PR DESCRIPTION
## Add hotkey to generate DROP TABLE query

### What’s changed

Introduced a keyboard shortcut that automatically generates a `DROP TABLE` SQL statement for the currently selected table.

### Why

Speeds up working with table management and reduces manual effort when composing destructive SQL queries.

### How it works

* User selects a table
* Triggers the assigned hotkey
* A `DROP TABLE` query is generated for the selected table

### Impact

* No changes to existing query generation logic
* Adds a new keyboard shortcut to the UI
* Safe behavior: only generates the query, does not execute it
