### PR TITLE
fix(oracle): CLOB/BLOB queries no longer hang the TUI (fetch LOBs inline + never drop unserializable worker results)

### DIFF
--- a/sqlit/domains/connections/providers/oracle/adapter.py
+++ b/sqlit/domains/connections/providers/oracle/adapter.py
@@ -94,6 +94,13 @@ class OracleAdapter(DatabaseAdapter):
             package_name=self.install_package,
         )
 
+        # Fetch CLOB/BLOB values inline as str/bytes instead of LOB locators.
+        # Locators need a live connection to be read, but results are pickled
+        # across the process worker pipe after the query connection is closed,
+        # which raises DPY-1001 mid-serialization. Inline fetch also avoids
+        # one extra round trip per LOB per row.
+        oracledb.defaults.fetch_lobs = False
+
         endpoint = config.tcp_endpoint
         if endpoint is None:
             raise ValueError("Oracle connections require a TCP-style endpoint.")
@@ -376,6 +383,10 @@ class OracleAdapter(DatabaseAdapter):
         """Execute a query on Oracle with optional row limit."""
         cursor = conn.cursor()
         try:
+            # Larger fetch batches cut per-round-trip overhead on high-latency
+            # links (oracledb defaults: arraysize=100, prefetchrows=2).
+            cursor.arraysize = 1000
+            cursor.prefetchrows = 1001
             cursor.execute(_prepare_statement(query))
             if cursor.description:
                 columns = [col[0] for col in cursor.description]

--- a/sqlit/domains/process_worker/app/process_worker.py
+++ b/sqlit/domains/process_worker/app/process_worker.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import faulthandler
 import os
-import pickle
 import sys
 import tempfile
 import threading
@@ -80,9 +79,15 @@ class _WorkerState:
             try:
                 self.conn.send(payload)
                 return
-            except (TypeError, AttributeError, pickle.PickleError) as exc:
-                # Result isn't picklable. Replace with an error so the
-                # client surfaces it instead of hanging on recv().
+            except OSError:
+                # Pipe closed; nothing we can do.
+                return
+            except Exception as exc:
+                # Result couldn't be serialized: not picklable, or a driver
+                # error raised while pickling — e.g. oracledb LOB locators
+                # read from an already-closed connection (DPY-1001). Replace
+                # with an error so the client surfaces it instead of hanging
+                # on recv().
                 fallback = {
                     "type": "error",
                     "id": payload.get("id"),
@@ -95,9 +100,6 @@ class _WorkerState:
                     self.conn.send(fallback)
                 except Exception:
                     pass
-            except Exception:
-                # Pipe closed or similar; nothing we can do.
-                pass
 
     def _ensure_tunnel(self, config: ConnectionConfig) -> Any | None:
         key = _tunnel_key(config)

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -150,6 +150,24 @@ class TestOracleIntegration(BaseDatabaseTests):
         assert "Bob" in result.stdout
         assert "2 row(s) returned" in result.stdout
 
+    def test_query_oracle_clob_returns_text(self, oracle_connection, cli_runner):
+        """CLOB values must be fetched inline as text, not LOB locators.
+
+        With oracledb's default fetch_lobs=True, rows contain LOB locator
+        objects: the CLI renders their repr instead of the value, and the
+        TUI's process worker hangs pickling them after the query connection
+        is closed (issue #276).
+        """
+        result = cli_runner(
+            "query",
+            "-c",
+            oracle_connection,
+            "-q",
+            "SELECT TO_CLOB('clob value ok') AS payload FROM DUAL",
+        )
+        assert result.returncode == 0
+        assert "clob value ok" in result.stdout
+
     def test_delete_oracle_connection(self, oracle_db, cli_runner):
         """Test deleting an Oracle connection."""
         from .conftest import ORACLE_HOST, ORACLE_PASSWORD, ORACLE_PORT, ORACLE_USER

--- a/tests/unit/test_process_worker_pickle_safety.py
+++ b/tests/unit/test_process_worker_pickle_safety.py
@@ -123,6 +123,44 @@ def test_worker_send_non_picklable_payload_emits_error() -> None:
         state.conn.close()
 
 
+class _RaisesOnPickle:
+    """Simulates an oracledb LOB locator whose connection already closed.
+
+    Pickling a LOB locator reads its value from the database, so it raises
+    the driver's InterfaceError (DPY-1001) — an Exception subclass that is
+    neither TypeError, AttributeError, nor PickleError.
+    """
+
+    def __reduce__(self) -> Any:
+        raise RuntimeError("DPY-1001: not connected to database")
+
+
+def test_worker_send_pickle_raising_driver_error_emits_error() -> None:
+    """Regression test for issue #276: oracledb CLOB/BLOB results raised
+    InterfaceError during pickling, which fell through to a bare
+    `except Exception: pass` — the payload was dropped and the client
+    hung on recv() forever.
+    """
+    state, parent = _make_state_with_pipe()
+    try:
+        payload: dict[str, Any] = {
+            "type": "result",
+            "id": 7,
+            "kind": "query",
+            "result": _RaisesOnPickle(),
+        }
+        state.send(payload)
+
+        assert parent.poll(timeout=2.0), "client would hang; no error message was sent"
+        message = parent.recv()
+        assert message["type"] == "error"
+        assert message["id"] == 7
+        assert "DPY-1001" in message["message"]
+    finally:
+        parent.close()
+        state.conn.close()
+
+
 def test_worker_send_picklable_payload_passes_through() -> None:
     """Confirm the fallback path doesn't interfere with normal sends."""
     state, parent = _make_state_with_pipe()


### PR DESCRIPTION
Fixes #276.

## What was happening

Any query returning CLOB/BLOB columns against Oracle hung the TUI forever (spinner never stopped). Three things lined up:

1. `CancellableQuery.execute()` closes its dedicated connection before the worker serializes the result across the process worker pipe.
2. With oracledb's default `fetch_lobs = True`, rows contain LOB locators. Pickling a locator reads its value from the database — with the connection already closed that raises `InterfaceError: DPY-1001`.
3. `_WorkerState.send()` only caught `(TypeError, AttributeError, pickle.PickleError)` when building the error fallback. The `InterfaceError` fell through to a bare `except Exception: pass`, so the payload was silently dropped and the client stayed blocked on `recv()` forever.

Full analysis, reproduction and timing measurements are in #276.

## Changes

- **`oracle/adapter.py`** — set `oracledb.defaults.fetch_lobs = False` in `connect()`, so CLOB/BLOB come back inline as `str`/`bytes`. This fixes the root cause and also removes one extra round trip per LOB per row. Also raises `cursor.arraysize`/`prefetchrows` from the driver defaults (100/2), which cut a 5 000-row fetch over a ~137 ms WAN link from 8.6 s to 2.9 s in my measurements.
- **`process_worker.py`** — `_WorkerState.send()` now treats `OSError` as pipe-closed and *every other* exception as a serialization failure that must produce an error reply. No result can be silently dropped anymore, whatever driver misbehaves next (defence-in-depth on top of the pickle-safety work from #161/#171).
- **Tests** — unit regression test for the swallowed-exception path (fails on `main`, passes with the fix), and an Oracle integration test asserting CLOB values come back as text.

## Verification

- Reproduced the hang headless with Textual Pilot against Oracle 19c on AWS RDS: a `SELECT` on a CLOB table hung 300 s+ on `main`, returns rendered results in ~1.5 s with this branch.
- `pytest tests/unit/test_process_worker_pickle_safety.py tests/unit/test_process_worker_fallback.py tests/unit/test_process_worker_statement_validation.py tests/unit/test_oracle_adapter.py` — all green.
- The new unit test fails on `main` (payload dropped, client would hang) and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
