### PR TITLE
Fix MSSQL Docker discovery on IPv4 loopback

### DIFF
--- a/sqlit/domains/connections/providers/mssql/provider.py
+++ b/sqlit/domains/connections/providers/mssql/provider.py
@@ -32,6 +32,7 @@ SPEC = ProviderSpec(
             "database": (),
         },
         default_user="sa",
+        preferred_host="127.0.0.1",
     ),
 )
 

--- a/tests/integration/docker_detect/test_all_databases.py
+++ b/tests/integration/docker_detect/test_all_databases.py
@@ -18,11 +18,11 @@ from tests.integration.docker_detect.database_configs import (
     DatabaseTestConfig,
 )
 
-_TCP_ONLY_HOSTS = {"mysql", "mariadb"}
+_IPV4_LOOPBACK_HOSTS = {"mysql", "mariadb", "mssql"}
 
 
 def _expected_host(db_type: str) -> str:
-    return "127.0.0.1" if db_type in _TCP_ONLY_HOSTS else "localhost"
+    return "127.0.0.1" if db_type in _IPV4_LOOPBACK_HOSTS else "localhost"
 
 
 def is_docker_available() -> bool:

--- a/tests/integration/docker_detect/test_docker_detection.py
+++ b/tests/integration/docker_detect/test_docker_detection.py
@@ -27,11 +27,11 @@ from sqlit.domains.connections.discovery.docker_detector import (
 if TYPE_CHECKING:
     pass
 
-_TCP_ONLY_HOSTS = {"mysql", "mariadb"}
+_IPV4_LOOPBACK_HOSTS = {"mysql", "mariadb", "mssql"}
 
 
 def _expected_host(db_type: str) -> str:
-    return "127.0.0.1" if db_type in _TCP_ONLY_HOSTS else "localhost"
+    return "127.0.0.1" if db_type in _IPV4_LOOPBACK_HOSTS else "localhost"
 
 
 def is_docker_available() -> bool:

--- a/tests/test_docker_detector.py
+++ b/tests/test_docker_detector.py
@@ -325,6 +325,38 @@ class TestDetectDatabaseContainers:
             assert containers[0].database == "testdb"
             assert containers[0].connectable is True
 
+    def test_detected_mssql_container_uses_ipv4_loopback(self):
+        """Test MSSQL Docker connections use IPv4 loopback."""
+        mock_container = MagicMock()
+        mock_container.name = "test-mssql"
+        mock_container.short_id = "abc123"
+        mock_container.image.tags = ["mcr.microsoft.com/mssql/server:2022-latest"]
+        mock_container.attrs = {
+            "Config": {"Env": ["MSSQL_SA_PASSWORD=test-password"]},
+            "HostConfig": {"NetworkMode": "bridge"},
+            "NetworkSettings": {
+                "Ports": {
+                    "1433/tcp": [{"HostIp": "127.0.0.1", "HostPort": "1433"}],
+                }
+            },
+        }
+
+        mock_client = MagicMock()
+        mock_client.containers.list.side_effect = [[mock_container], []]
+
+        with (
+            patch(
+                "sqlit.domains.connections.discovery.docker_detector.get_docker_status",
+                return_value=DockerStatus.AVAILABLE,
+            ),
+            patch("docker.from_env", return_value=mock_client),
+        ):
+            _, containers = detect_database_containers()
+
+        assert len(containers) == 1
+        assert containers[0].host == "127.0.0.1"
+        assert container_to_connection_config(containers[0]).server == "127.0.0.1"
+
     def test_detect_container_tagless_image(self):
         """Test detection when image tags are missing."""
         mock_container = MagicMock()


### PR DESCRIPTION
## Summary

- use IPv4 loopback for Docker-discovered SQL Server connections
- cover the selected host through connection configuration
- keep Docker integration expectations aligned

## Why

This surfaced while using sqlit to auto-connect to an Aspire-managed SQL Server container. Docker discovery found the mapped port and credentials, but `localhost` resolved to `::1` while SQL Server was published on IPv4 loopback, so the connection failed.

The change is MSSQL-specific. Manual connections and other providers are unchanged.

## Tests

- regression test failed before the change and passed afterward
- affected Docker-discovery suite: 43 passed, 32 opt-in tests skipped
- focused Ruff and MyPy checks

_Implementation and review were AI-assisted; the final diff and test evidence were manually reviewed._