### PR TITLE
ci: simplify workflows with uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, master]
 
+# Applies to every `uv` invocation below, so --locked need not be repeated
+# in 15 jobs. Fails the run if uv.lock is out of date with pyproject.toml.
+env:
+  UV_LOCKED: "1"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,23 +21,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-          pip install -e .
+          enable-cache: true
 
       - name: Check package builds
-        run: python -m build
+        run: uv build
 
       - name: Verify CLI entry point
-        run: |
-          python -c "from sqlit.cli import main; print('CLI import OK')"
+        run: uv run --no-dev python -c "from sqlit.cli import main; print('CLI import OK')"
 
   nix-flake:
     runs-on: ubuntu-latest
@@ -54,16 +52,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev
+          enable-cache: true
 
       - name: Run unit tests
         run: |
@@ -90,16 +82,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev
+          enable-cache: true
 
       - name: Run SQLite integration tests
         run: uv run pytest tests/test_sqlite.py -v --timeout=60
@@ -127,16 +113,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra mssql
+          enable-cache: true
 
       - name: Wait for SQL Server to be ready
         run: |
@@ -155,7 +135,7 @@ jobs:
           MSSQL_PORT: 1433
           MSSQL_USER: sa
           MSSQL_PASSWORD: TestPassword123!
-        run: uv run pytest tests/test_mssql.py -v --timeout=120
+        run: uv run --extra mssql pytest tests/test_mssql.py -v --timeout=120
 
   test-postgresql:
     runs-on: ubuntu-latest
@@ -180,16 +160,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra postgres
+          enable-cache: true
 
       - name: Run PostgreSQL integration tests
         env:
@@ -198,7 +172,7 @@ jobs:
           POSTGRES_USER: testuser
           POSTGRES_PASSWORD: TestPassword123!
           POSTGRES_DATABASE: test_sqlit
-        run: uv run pytest tests/test_postgresql.py -v --timeout=120
+        run: uv run --extra postgres pytest tests/test_postgresql.py -v --timeout=120
 
   test-mysql:
     runs-on: ubuntu-latest
@@ -224,16 +198,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra mysql
+          enable-cache: true
 
       - name: Run MySQL integration tests
         env:
@@ -242,7 +210,7 @@ jobs:
           MYSQL_USER: root
           MYSQL_PASSWORD: TestPassword123!
           MYSQL_DATABASE: test_sqlit
-        run: uv run pytest tests/test_mysql.py -v --timeout=120
+        run: uv run --extra mysql pytest tests/test_mysql.py -v --timeout=120
 
   test-oracle:
     runs-on: ubuntu-latest
@@ -267,16 +235,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra oracle
+          enable-cache: true
 
       - name: Run Oracle integration tests
         env:
@@ -285,7 +247,7 @@ jobs:
           ORACLE_USER: testuser
           ORACLE_PASSWORD: TestPassword123!
           ORACLE_SERVICE: FREEPDB1
-        run: uv run pytest tests/test_oracle.py -v --timeout=120
+        run: uv run --extra oracle pytest tests/test_oracle.py -v --timeout=120
 
   test-mariadb:
     runs-on: ubuntu-latest
@@ -311,21 +273,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
+          enable-cache: true
 
       - name: Install MariaDB Connector/C
         run: |
           sudo apt-get update
           sudo apt-get install -y libmariadb-dev
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra mariadb
 
       - name: Run MariaDB integration tests
         env:
@@ -334,7 +290,7 @@ jobs:
           MARIADB_USER: root
           MARIADB_PASSWORD: TestPassword123!
           MARIADB_DATABASE: test_sqlit
-        run: uv run pytest tests/test_mariadb.py -v --timeout=120
+        run: uv run --extra mariadb pytest tests/test_mariadb.py -v --timeout=120
 
   test-duckdb:
     runs-on: ubuntu-latest
@@ -345,19 +301,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra duckdb
+          enable-cache: true
 
       - name: Run DuckDB integration tests
-        run: uv run pytest tests/test_duckdb.py -v --timeout=60
+        run: uv run --extra duckdb pytest tests/test_duckdb.py -v --timeout=60
 
   test-cockroachdb:
     runs-on: ubuntu-latest
@@ -366,16 +316,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra cockroachdb
+          enable-cache: true
 
       - name: Start CockroachDB
         run: |
@@ -398,7 +342,7 @@ jobs:
           COCKROACHDB_USER: root
           COCKROACHDB_PASSWORD: ""
           COCKROACHDB_DATABASE: test_sqlit
-        run: uv run pytest tests/test_cockroachdb.py -v --timeout=120
+        run: uv run --extra cockroachdb pytest tests/test_cockroachdb.py -v --timeout=120
 
   test-firebird:
     runs-on: ubuntu-latest
@@ -417,16 +361,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra firebird
+          enable-cache: true
 
       - name: Run Firebird integration tests
         env:
@@ -435,7 +373,7 @@ jobs:
           FIREBIRD_USER: testuser
           FIREBIRD_PASSWORD: TestPassword123!
           FIREBIRD_DATABASE: /var/lib/firebird/data/test_sqlit.fdb
-        run: uv run pytest tests/test_firebird.py -v --timeout=120
+        run: uv run --extra firebird pytest tests/test_firebird.py -v --timeout=120
 
   test-clickhouse:
     runs-on: ubuntu-latest
@@ -444,16 +382,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra clickhouse
+          enable-cache: true
 
       - name: Start ClickHouse
         run: |
@@ -478,7 +410,7 @@ jobs:
           CLICKHOUSE_USER: default
           CLICKHOUSE_PASSWORD: testpass
           CLICKHOUSE_DATABASE: test_sqlit
-        run: uv run pytest tests/test_clickhouse.py -v --timeout=120
+        run: uv run --extra clickhouse pytest tests/test_clickhouse.py -v --timeout=120
 
   test-ssh:
     runs-on: ubuntu-latest
@@ -487,16 +419,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra ssh --extra postgres
+          enable-cache: true
 
       - name: Create Docker network
         run: docker network create ssh-test-net
@@ -553,7 +479,7 @@ jobs:
           POSTGRES_USER: testuser
           POSTGRES_PASSWORD: TestPassword123!
           POSTGRES_DATABASE: test_sqlit
-        run: uv run pytest tests/test_ssh.py -v --timeout=120
+        run: uv run --extra ssh --extra postgres pytest tests/test_ssh.py -v --timeout=120
 
       - name: Cleanup
         if: always()
@@ -569,16 +495,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Install dependencies
-        run: uv sync --group test --no-dev --extra turso
+          enable-cache: true
 
       - name: Start Turso (libsql-server)
         run: |
@@ -598,7 +518,7 @@ jobs:
       - name: Run Turso integration tests
         env:
           TURSO_URL: http://localhost:8080
-        run: uv run pytest tests/test_turso.py -v --timeout=120
+        run: uv run --extra turso pytest tests/test_turso.py -v --timeout=120
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,11 @@ on:
   pull_request:
     branches: [main, master]
 
-# Applies to every `uv` invocation below, so --locked need not be repeated
-# in 15 jobs. Fails the run if uv.lock is out of date with pyproject.toml.
+# Read by every `uv` invocation below. UV_LOCKED fails the run if uv.lock is
+# out of date with pyproject.toml; UV_PYTHON is overridden by the matrix jobs.
 env:
   UV_LOCKED: "1"
+  UV_PYTHON: "3.12"
 
 jobs:
   build:
@@ -18,13 +19,13 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Check package builds
         run: uv build
@@ -49,17 +50,17 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12"]
 
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Run unit tests
         run: |
-          uv run pytest tests/ -v --timeout=60 \
+          uv run pytest tests/ --timeout=60 \
             --ignore=tests/test_sqlite.py \
             --ignore=tests/test_mssql.py \
             --ignore=tests/test_postgresql.py \
@@ -79,16 +80,16 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12"]
 
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Run SQLite integration tests
-        run: uv run pytest tests/test_sqlite.py -v --timeout=60
+        run: uv run pytest tests/test_sqlite.py --timeout=60
 
   test-mssql:
     runs-on: ubuntu-latest
@@ -113,10 +114,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Wait for SQL Server to be ready
         run: |
@@ -135,7 +133,7 @@ jobs:
           MSSQL_PORT: 1433
           MSSQL_USER: sa
           MSSQL_PASSWORD: TestPassword123!
-        run: uv run --extra mssql pytest tests/test_mssql.py -v --timeout=120
+        run: uv run --extra mssql pytest tests/test_mssql.py --timeout=120
 
   test-postgresql:
     runs-on: ubuntu-latest
@@ -160,10 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Run PostgreSQL integration tests
         env:
@@ -172,7 +167,7 @@ jobs:
           POSTGRES_USER: testuser
           POSTGRES_PASSWORD: TestPassword123!
           POSTGRES_DATABASE: test_sqlit
-        run: uv run --extra postgres pytest tests/test_postgresql.py -v --timeout=120
+        run: uv run --extra postgres pytest tests/test_postgresql.py --timeout=120
 
   test-mysql:
     runs-on: ubuntu-latest
@@ -198,10 +193,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Run MySQL integration tests
         env:
@@ -210,7 +202,7 @@ jobs:
           MYSQL_USER: root
           MYSQL_PASSWORD: TestPassword123!
           MYSQL_DATABASE: test_sqlit
-        run: uv run --extra mysql pytest tests/test_mysql.py -v --timeout=120
+        run: uv run --extra mysql pytest tests/test_mysql.py --timeout=120
 
   test-oracle:
     runs-on: ubuntu-latest
@@ -235,10 +227,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Run Oracle integration tests
         env:
@@ -247,7 +236,7 @@ jobs:
           ORACLE_USER: testuser
           ORACLE_PASSWORD: TestPassword123!
           ORACLE_SERVICE: FREEPDB1
-        run: uv run --extra oracle pytest tests/test_oracle.py -v --timeout=120
+        run: uv run --extra oracle pytest tests/test_oracle.py --timeout=120
 
   test-mariadb:
     runs-on: ubuntu-latest
@@ -273,10 +262,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Install MariaDB Connector/C
         run: |
@@ -290,7 +276,7 @@ jobs:
           MARIADB_USER: root
           MARIADB_PASSWORD: TestPassword123!
           MARIADB_DATABASE: test_sqlit
-        run: uv run --extra mariadb pytest tests/test_mariadb.py -v --timeout=120
+        run: uv run --extra mariadb pytest tests/test_mariadb.py --timeout=120
 
   test-duckdb:
     runs-on: ubuntu-latest
@@ -298,16 +284,16 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12"]
 
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Run DuckDB integration tests
-        run: uv run --extra duckdb pytest tests/test_duckdb.py -v --timeout=60
+        run: uv run --extra duckdb pytest tests/test_duckdb.py --timeout=60
 
   test-cockroachdb:
     runs-on: ubuntu-latest
@@ -316,10 +302,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Start CockroachDB
         run: |
@@ -342,7 +325,7 @@ jobs:
           COCKROACHDB_USER: root
           COCKROACHDB_PASSWORD: ""
           COCKROACHDB_DATABASE: test_sqlit
-        run: uv run --extra cockroachdb pytest tests/test_cockroachdb.py -v --timeout=120
+        run: uv run --extra cockroachdb pytest tests/test_cockroachdb.py --timeout=120
 
   test-firebird:
     runs-on: ubuntu-latest
@@ -361,10 +344,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Run Firebird integration tests
         env:
@@ -373,7 +353,7 @@ jobs:
           FIREBIRD_USER: testuser
           FIREBIRD_PASSWORD: TestPassword123!
           FIREBIRD_DATABASE: /var/lib/firebird/data/test_sqlit.fdb
-        run: uv run --extra firebird pytest tests/test_firebird.py -v --timeout=120
+        run: uv run --extra firebird pytest tests/test_firebird.py --timeout=120
 
   test-clickhouse:
     runs-on: ubuntu-latest
@@ -382,10 +362,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Start ClickHouse
         run: |
@@ -410,7 +387,7 @@ jobs:
           CLICKHOUSE_USER: default
           CLICKHOUSE_PASSWORD: testpass
           CLICKHOUSE_DATABASE: test_sqlit
-        run: uv run --extra clickhouse pytest tests/test_clickhouse.py -v --timeout=120
+        run: uv run --extra clickhouse pytest tests/test_clickhouse.py --timeout=120
 
   test-ssh:
     runs-on: ubuntu-latest
@@ -419,10 +396,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Create Docker network
         run: docker network create ssh-test-net
@@ -479,14 +453,7 @@ jobs:
           POSTGRES_USER: testuser
           POSTGRES_PASSWORD: TestPassword123!
           POSTGRES_DATABASE: test_sqlit
-        run: uv run --extra ssh --extra postgres pytest tests/test_ssh.py -v --timeout=120
-
-      - name: Cleanup
-        if: always()
-        run: |
-          docker stop sshserver postgres || true
-          docker rm sshserver postgres || true
-          docker network rm ssh-test-net || true
+        run: uv run --extra ssh --extra postgres pytest tests/test_ssh.py --timeout=120
 
   test-turso:
     runs-on: ubuntu-latest
@@ -495,10 +462,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
-        with:
-          python-version: "3.12"
-          enable-cache: true
+      - uses: astral-sh/setup-uv@v7
 
       - name: Start Turso (libsql-server)
         run: |
@@ -518,10 +482,5 @@ jobs:
       - name: Run Turso integration tests
         env:
           TURSO_URL: http://localhost:8080
-        run: uv run --extra turso pytest tests/test_turso.py -v --timeout=120
+        run: uv run --extra turso pytest tests/test_turso.py --timeout=120
 
-      - name: Cleanup
-        if: always()
-        run: |
-          docker stop turso || true
-          docker rm turso || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,16 +51,12 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v5
         with:
           python-version: "3.12"
 
-      - name: Install build tools
-        run: python -m pip install --upgrade build
-
       - name: Build package
-        run: python -m build
+        run: uv build
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Reimplementation of the CI half of #157, which you closed as "several separate ideas bundled together". Split into focused commits so each can land on its own.

`ci.yml` drops from 607 to 486 lines with no change in what CI covers. Job names are unchanged, so required status checks keep matching.

## Commits

### `ci: drive CI entirely through uv`

`setup-uv` supplies the interpreter, so `actions/setup-python` is redundant. `uv run` syncs on demand, so the standalone `uv sync` step is too. Every job goes from 4 or 5 setup steps to 2:

```yaml
- uses: actions/checkout@v4
- uses: astral-sh/setup-uv@v7
- name: Run PostgreSQL integration tests
  env: { ... }
  run: uv run --extra postgres pytest tests/test_postgresql.py --timeout=120
```

Also `uv build` in place of `pip install build && python -m build`, and `UV_LOCKED` at workflow level so CI fails on a stale `uv.lock`.

### `ci(release): build the package with uv build`

The same swap in `release.yml`. Nothing else in that workflow is touched. Publish and AUR are left alone on purpose, since churn there buys nothing. Same build backend and same PEP 625 artifact names, so the AUR job's `dist/sqlit_tui-${VERSION}.tar.gz` lookup is unaffected.

### `ci: cut redundant workflow config`

Four deletions:

* `setup-uv` v5 to v7, which defaults `enable-cache` to `auto` and removes 15 explicit lines. v7 is the newest moving major tag that actually exists; v8 and v9 are published only as full version tags. That is the same class of mistake you caught with the AUR action in #157, so I checked `git ls-remote` this time.
* `UV_PYTHON` at workflow level, overridden per matrix job, replacing 15 copies of setup-uv's `python-version` input.
* `-v` dropped from every pytest call, since `pyproject.toml` already sets `addopts = "-v"`.
* The trailing `docker stop/rm` cleanup steps in `test-ssh` and `test-turso`. Runners are ephemeral, and the four other `docker run` jobs never had them.

## Why not the approach in #157

Its deduplication relied on YAML anchors (`&checkout-step` / `*checkout-step`). GitHub Actions does not expand aliases, so that could never have worked. This PR gets the same effect from workflow-level `env` and action defaults instead.

## One behaviour note worth knowing

The old jobs ran `uv sync --group test --no-dev` and then a bare `uv run`, which re-syncs the default (dev) group. So `--no-dev` never actually took effect, and CI has always installed `dev`. This PR preserves that.

An earlier draft of mine "fixed" it with `UV_NO_DEV=1` and silently skipped the 11 `tests/performance` tests, because `Faker` lives in `dev` and the file `skipif`s itself away when it is missing. Making `--no-dev` real would need `Faker` and `pytest-benchmark` moved into the `test` group, which is a `pyproject.toml` change and not bundled here.

## Verification

`actionlint` clean on both files. Locally, with `UV_LOCKED=1`:

```
uv build                             -> sqlit_tui-<ver>.tar.gz + .whl
uv run --no-dev python -c "..."      -> CLI import OK
uv run pytest tests/test_sqlite.py   -> 25 passed, 6 skipped
uv run --extra duckdb ...test_duckdb -> 29 passed, 5 skipped
uv run pytest tests/ <12 ignores>    -> 1756 passed, 420 skipped, 1 failed
uv lock --check                      -> in sync, so UV_LOCKED is safe
```

The single failure, `test_detect_strategy_pip_user_fallback`, is pre-existing and environment-dependent. The probe reads real interpreter state, and my machine reports `externally-managed` where the test expects `pip-user`. It fails identically on unmodified `main`.

I also could not get a clean local reading on `tests/performance`, which asserts wall-clock thresholds. Those tests passed standalone, then failed inside a full run while my machine was busy with other test invocations. Not caused by this PR, since they already run in the current unit job, but they look like a latent flake worth a separate look.

## Deliberately left out

Happy to open any of these separately if you want them:

* The 13 near-identical DB jobs. A matrix would work, since `services:` accepts matrix expressions, but four jobs use raw `docker run`, mssql needs a wait step, mariadb needs apt, and firebird has no healthcheck. The resulting `include:` block is harder to read than 13 explicit jobs.
* `build` builds the same `py3-none-any` wheel four times. It could collapse to one job, with `test-unit` widened to all four versions instead. That is fewer jobs and more real coverage, at roughly double the unit-job wall time.
* The 12-line `--ignore` list. `tests/integration/` already exists and `pytest.mark.integration` is already declared in `pyproject.toml`, but the DB test files use neither. Marking or moving them turns that list into `-m "not integration"`.
* `softprops/action-gh-release@v1` in `release.yml`. actionlint flags it as too old to run on GitHub Actions (node16). Pre-existing, one character to fix, own PR.