### PR TITLE
Handle CR line endings in the query editor

### DIFF
--- a/sqlit/domains/query/editing/clipboard.py
+++ b/sqlit/domains/query/editing/clipboard.py
@@ -27,6 +27,7 @@ def select_all_range(text: str) -> tuple[int, int, int, int]:
 
 def paste_text(text: str, row: int, col: int, clipboard: str) -> PasteResult:
     """Paste clipboard content at cursor position."""
+    clipboard = clipboard.replace("\r\n", "\n").replace("\r", "\n")
     lines = text.split("\n")
     if not lines:
         lines = [""]

--- a/sqlit/domains/query/ui/mixins/autocomplete.py
+++ b/sqlit/domains/query/ui/mixins/autocomplete.py
@@ -69,7 +69,10 @@ class AutocompleteMixin(AutocompleteSchemaMixin, AutocompleteSuggestionsMixin):
         cursor_pos = self._location_to_offset(text, cursor_loc)
 
         word_start = cursor_pos
-        while word_start > 0 and text[word_start - 1] not in " \t\n,()[].":
+        while word_start > 0:
+            previous = text[word_start - 1]
+            if previous in " \t\r\n,()[].":
+                break
             word_start -= 1
 
         if word_start > 0 and text[word_start - 1] == ".":

--- a/sqlit/domains/query/ui/mixins/autocomplete.py
+++ b/sqlit/domains/query/ui/mixins/autocomplete.py
@@ -88,20 +88,28 @@ class AutocompleteMixin(AutocompleteSchemaMixin, AutocompleteSuggestionsMixin):
     def _location_to_offset(self, text: str, location: tuple[int, int]) -> int:
         """Convert (row, col) location to text offset."""
         row, col = location
-        lines = text.split("\n")
-        offset = sum(len(lines[i]) + 1 for i in range(row))
-        offset += col
+        lines = text.splitlines(keepends=True)
+        offset = sum(len(line) for line in lines[:row]) + col
         return min(offset, len(text))
 
     def _offset_to_location(self, text: str, offset: int) -> tuple[int, int]:
         """Convert text offset to (row, col) location."""
-        lines = text.split("\n")
+        lines = text.splitlines(keepends=True)
+        if not lines:
+            return (0, 0)
+
         current_offset = 0
         for row, line in enumerate(lines):
-            if current_offset + len(line) >= offset:
+            content_length = len(line.rstrip("\r\n"))
+            if current_offset + content_length >= offset:
                 return (row, offset - current_offset)
-            current_offset += len(line) + 1
-        return (len(lines) - 1, len(lines[-1]) if lines else 0)
+            current_offset += len(line)
+            if offset < current_offset:
+                return (row, content_length)
+
+        if lines and lines[-1].endswith(("\r", "\n")):
+            return (len(lines), 0)
+        return (len(lines) - 1, len(lines[-1]))
 
     def on_text_area_changed(self: AutocompleteMixinHost, event: TextArea.Changed) -> None:
         """Handle text changes in the query editor for autocomplete."""

--- a/tests/unit/test_autocomplete_cr_line_endings.py
+++ b/tests/unit/test_autocomplete_cr_line_endings.py
@@ -1,0 +1,53 @@
+"""Regression coverage for CR-only text reaching autocomplete."""
+
+from sqlit.domains.query.ui.mixins.autocomplete import AutocompleteMixin
+
+
+class _QueryInput:
+    def __init__(self, text: str, cursor_location: tuple[int, int]) -> None:
+        self.text = text
+        self.cursor_location = cursor_location
+
+
+class _Dropdown:
+    def __init__(self, selected: str = "FROM") -> None:
+        self.selected = selected
+
+    def get_selected(self) -> str:
+        return self.selected
+
+    def hide(self) -> None:
+        pass
+
+
+class _Host(AutocompleteMixin):
+    def __init__(
+        self,
+        text: str,
+        cursor_location: tuple[int, int],
+        selected: str = "FROM",
+    ) -> None:
+        self.query_input = _QueryInput(text, cursor_location)
+        self.autocomplete_dropdown = _Dropdown(selected)
+        self._autocomplete_visible = True
+
+
+def test_apply_autocomplete_after_cr_only_line_break() -> None:
+    """A completion after CR-only text replaces only the current word."""
+    host = _Host("SELECT\rONE\rFR", (2, 2))
+
+    host._apply_autocomplete()
+
+    assert host.query_input.text == "SELECT\rONE\rFROM"
+    assert host.query_input.cursor_location == (2, 4)
+
+
+def test_apply_autocomplete_preserves_non_ascii_identifier_whitespace() -> None:
+    """Only SQL separators, not every Unicode whitespace, delimit identifiers."""
+    identifier = "foo\N{NO-BREAK SPACE}bar"
+    partial = "foo\N{NO-BREAK SPACE}b"
+    host = _Host(partial, (0, len(partial)), selected=identifier)
+
+    host._apply_autocomplete()
+
+    assert host.query_input.text == identifier

--- a/tests/unit/test_autocomplete_cursor_positions.py
+++ b/tests/unit/test_autocomplete_cursor_positions.py
@@ -1,0 +1,32 @@
+"""Tests for cursor position conversion used by autocomplete."""
+
+import pytest
+
+from sqlit.domains.query.ui.mixins.autocomplete import AutocompleteMixin
+
+
+@pytest.mark.parametrize("separator", ["\n", "\r\n", "\r"])
+def test_cursor_location_round_trip_for_line_endings(separator: str) -> None:
+    """Cursor conversion supports all common pasted-text line endings."""
+    lines = ["SELECT", "    column_name", "FROM users"]
+    text = separator.join(lines)
+    location = (2, 4)
+    expected_offset = len(lines[0]) + len(separator) + len(lines[1]) + len(separator) + location[1]
+
+    offset = AutocompleteMixin._location_to_offset(None, text, location)
+
+    assert offset == expected_offset
+    assert AutocompleteMixin._offset_to_location(None, text, offset) == location
+
+
+@pytest.mark.parametrize("separator", ["\n", "\r\n", "\r"])
+def test_offset_to_location_after_trailing_line_ending(separator: str) -> None:
+    """An offset after a trailing line ending maps to the next empty row."""
+    text = f"SELECT{separator}"
+
+    assert AutocompleteMixin._offset_to_location(None, text, len(text)) == (1, 0)
+
+
+def test_offset_to_location_for_empty_text() -> None:
+    """An empty editor starts at the first row and column."""
+    assert AutocompleteMixin._offset_to_location(None, "", 0) == (0, 0)

--- a/tests/unit/test_query_paste.py
+++ b/tests/unit/test_query_paste.py
@@ -1,0 +1,15 @@
+"""Tests for pasting text into the query editor."""
+
+import pytest
+
+from sqlit.domains.query.editing import PasteResult, paste_text
+
+
+@pytest.mark.parametrize("separator", ["\n", "\r\n", "\r"])
+def test_paste_normalizes_line_endings(separator: str) -> None:
+    """Pasted queries use the line endings expected by editor operations."""
+    clipboard = separator.join(["SELECT", "FROM users"])
+
+    result = paste_text("", 0, 0, clipboard)
+
+    assert result == PasteResult("SELECT\nFROM users", 1, 10)


### PR DESCRIPTION
## Summary

- normalize CRLF and CR-only clipboard text to LF before inserting it into the query editor
- preserve newline widths when converting autocomplete cursor locations to string offsets
- support LF, CRLF, and CR-only text in both cursor-conversion directions
- add regression coverage for pasted line endings, cursor round trips, trailing line endings, and empty text

## Root cause

The paste helper split clipboard content only on `\n`. CR-only clipboard content was therefore inserted unchanged even though Textual displayed it as multiple rows. That left the SQL highlighter and line-oriented editing operations with malformed input. Autocomplete also split only on `\n`, so Textual could report a multi-row cursor location while sqlit saw a single line, causing `_location_to_offset` to index past the line list.

## User impact

Pasted multiline SQL now uses the editor's expected LF representation, so syntax highlighting remains correct. Autocomplete also no longer crashes if CR or CRLF text reaches its cursor conversion helpers, and the cursor remains correctly positioned after applying a completion.

Fixes #292.

## Validation

- `pytest tests/unit/test_autocomplete_cursor_positions.py tests/unit/test_query_paste.py --timeout=60`: 10 passed
- `pytest tests/unit -q --timeout=60`: 1122 passed, 2 skipped
- `ruff check` on changed source and test files: passed
- `mypy` on changed source files: passed

Validation ran in a Python 3.12 container.