### PR TITLE
Add Ctrl+Delete word deletion in query editor

### DIFF
--- a/sqlit/shared/ui/widgets_text_area.py
+++ b/sqlit/shared/ui/widgets_text_area.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from rich.segment import Segment
+from textual.binding import Binding
 from textual.color import Color
 from textual.events import Key, Paste
 from textual.strip import Strip
@@ -17,6 +18,8 @@ if TYPE_CHECKING:
 
 class QueryTextArea(TextArea):
     """TextArea that intercepts clipboard keys and defers Enter to app."""
+
+    BINDINGS = [Binding("ctrl+delete", "delete_word_right", "Delete word right", show=False)]
 
     _last_text: str = ""
     _terminal_cursor_active: bool = False

--- a/tests/ui/test_query_word_deletion.py
+++ b/tests/ui/test_query_word_deletion.py
@@ -1,0 +1,29 @@
+"""UI tests for word deletion in the query editor."""
+
+from textual.app import App, ComposeResult
+
+from sqlit.core.vim import VimMode
+from sqlit.shared.ui.widgets_text_area import QueryTextArea
+
+
+class QueryWordDeletionApp(App[None]):
+    """Minimal app hosting a query editor in insert mode."""
+
+    vim_mode = VimMode.INSERT
+
+    def compose(self) -> ComposeResult:
+        yield QueryTextArea("SELECT column_name FROM users", id="query-input")
+
+
+async def test_ctrl_delete_deletes_word_to_the_right() -> None:
+    """Ctrl+Delete removes the word at the query cursor."""
+    app = QueryWordDeletionApp()
+
+    async with app.run_test() as pilot:
+        query_input = app.query_one("#query-input", QueryTextArea)
+        query_input.cursor_location = (0, 7)
+
+        await pilot.press("ctrl+delete")
+
+        assert query_input.text == "SELECT  FROM users"
+        assert query_input.cursor_location == (0, 7)


### PR DESCRIPTION
## Summary

- bind `Ctrl+Delete` in `QueryTextArea` to Textual's native `delete_word_right` action
- add a UI regression test that presses `Ctrl+Delete` and verifies both the resulting query text and cursor location

## Root cause

Textual provides the `delete_word_right` action and binds `Alt+Delete` to it, but the query editor did not provide the conventional `Ctrl+Delete` binding. The key therefore fell back to ordinary forward-character deletion.

## User impact

In query insert mode, `Ctrl+Delete` now deletes the word to the right while leaving the cursor in place.

Fixes #296.

## Validation

- `pytest tests/ui/test_query_word_deletion.py --timeout=60`: 1 passed
- `pytest tests/unit tests/ui -q --timeout=60`: 1413 passed, 2 skipped
- `ruff check sqlit/shared/ui/widgets_text_area.py tests/ui/test_query_word_deletion.py`: passed
- `mypy sqlit/shared/ui/widgets_text_area.py`: passed

Validation ran in a Python 3.12 container.