### PR TITLE
fix(readme): repair the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ If you try to create an SSH connection without these dependencies, sqlit will de
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Maxteabag/sqlit&type=Date)](https://star-history.com/#Maxteabag/sqlit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Maxteabag/sqlit&type=Date)](https://star-history.dera.page/#Maxteabag/sqlit&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart currently linked in the README is broken and no longer displays. This change points it to a working mirror of the star history service so the chart renders correctly again. No functionality is affected, only the chart link and image URL.