### PR TITLE
Fix Oracle cross-schema object discovery

### DIFF
--- a/sqlit/domains/connections/providers/oracle/adapter.py
+++ b/sqlit/domains/connections/providers/oracle/adapter.py
@@ -32,6 +32,29 @@ _PLSQL_START = re.compile(
 )
 
 
+def _dictionary_qualified_name(owner: str, name: str) -> str:
+    """Keep the owner/object boundary recoverable for quoted dotted names."""
+    if any(char in owner + name for char in '."'):
+
+        def quote(value: str) -> str:
+            return '"' + value.replace('"', '""') + '"'
+
+        return f"{quote(owner)}.{quote(name)}"
+    return f"{owner}.{name}"
+
+
+def _split_dictionary_name(value: str) -> tuple[str | None, str]:
+    """Decode names emitted by `_dictionary_qualified_name`."""
+    if value.startswith('"'):
+        match = re.fullmatch(r'"((?:""|[^"])*)"\."((?:""|[^"])*)"', value)
+        if match:
+            return match.group(1).replace('""', '"'), match.group(2).replace('""', '"')
+    if "." in value:
+        owner, name = value.split(".", 1)
+        return owner, name
+    return None, value.upper()
+
+
 def _prepare_statement(query: str) -> str:
     """Remove SQL*Plus terminators that python-oracledb does not accept."""
     statement = query.rstrip()
@@ -48,8 +71,8 @@ def _prepare_statement(query: str) -> str:
 class OracleAdapter(DatabaseAdapter):
     """Adapter for Oracle Database using oracledb.
 
-    Note: Oracle uses schemas extensively, but user_tables/user_views return
-    only objects owned by the current user (which acts as the default schema).
+    Oracle schemas are users.  The ALL_* dictionary views expose objects the
+    connected user may access, including objects owned by other schemas.
     """
 
     @property
@@ -127,9 +150,7 @@ class OracleAdapter(DatabaseAdapter):
             protocol_prefix = f"{protocol}://" if protocol in {"tcp", "tcps"} else ""
             dsn = f"{protocol_prefix}{endpoint.host}:{port}/{endpoint.database}"
 
-            parameters = str(
-                config.get_option("oracle_easy_connect_parameters", "") or ""
-            ).strip()
+            parameters = str(config.get_option("oracle_easy_connect_parameters", "") or "").strip()
             parameters = parameters.lstrip("?")
             if parameters:
                 dsn = f"{dsn}?{parameters}"
@@ -158,37 +179,52 @@ class OracleAdapter(DatabaseAdapter):
         return []
 
     def get_tables(self, conn: Any, database: str | None = None) -> list[TableInfo]:
-        """Get list of tables from Oracle. Returns (schema, name) with empty schema."""
+        """Get all tables accessible to the connected Oracle user."""
         cursor = conn.cursor()
         try:
-            cursor.execute("SELECT table_name FROM user_tables ORDER BY table_name")
-            # user_tables returns only current user's tables, so no schema prefix needed
-            return [("", row[0]) for row in cursor.fetchall()]
+            cursor.execute("SELECT owner, table_name FROM all_tables ORDER BY owner, table_name")
+            return [(row[0], row[1]) for row in cursor.fetchall()]
         finally:
             cursor.close()
 
     def get_views(self, conn: Any, database: str | None = None) -> list[TableInfo]:
-        """Get list of views from Oracle. Returns (schema, name) with empty schema."""
+        """Get all views accessible to the connected Oracle user."""
         cursor = conn.cursor()
         try:
-            cursor.execute("SELECT view_name FROM user_views ORDER BY view_name")
-            return [("", row[0]) for row in cursor.fetchall()]
+            cursor.execute("SELECT owner, view_name FROM all_views ORDER BY owner, view_name")
+            return [(row[0], row[1]) for row in cursor.fetchall()]
         finally:
             cursor.close()
 
-    def get_columns(
-        self, conn: Any, table: str, database: str | None = None, schema: str | None = None
-    ) -> list[ColumnInfo]:
-        """Get columns for a table from Oracle. Schema parameter is ignored."""
+    def get_columns(self, conn: Any, table: str, database: str | None = None, schema: str | None = None) -> list[ColumnInfo]:
+        """Get columns for a table from Oracle, scoped to its owning schema."""
+        if schema:
+            constraints_view = "all_constraints"
+            constraint_columns_view = "all_cons_columns"
+            columns_view = "all_tab_columns"
+            owner_clause = " AND cons.owner = :owner_name AND cols.owner = :owner_name"
+            columns_owner_clause = " AND owner = :owner_name"
+            params = {"table_name": table, "owner_name": schema}
+        else:
+            constraints_view = "user_constraints"
+            constraint_columns_view = "user_cons_columns"
+            columns_view = "user_tab_columns"
+            owner_clause = ""
+            columns_owner_clause = ""
+            params = {"table_name": table.upper()}
+
         # Get primary key columns
         pk_cursor = conn.cursor()
         try:
             pk_cursor.execute(
                 "SELECT cols.column_name "
-                "FROM user_constraints cons "
-                "JOIN user_cons_columns cols ON cons.constraint_name = cols.constraint_name "
-                "WHERE cons.constraint_type = 'P' AND cons.table_name = :1",
-                (table.upper(),),
+                f"FROM {constraints_view} cons "
+                f"JOIN {constraint_columns_view} cols "
+                "ON cons.constraint_name = cols.constraint_name "
+                "AND cons.owner = cols.owner "
+                "WHERE cons.constraint_type = 'P' AND cons.table_name = :table_name"
+                f"{owner_clause}",
+                params,
             )
             pk_columns = {row[0] for row in pk_cursor.fetchall()}
         finally:
@@ -198,8 +234,8 @@ class OracleAdapter(DatabaseAdapter):
         cursor = conn.cursor()
         try:
             cursor.execute(
-                "SELECT column_name, data_type FROM user_tab_columns " "WHERE table_name = :1 ORDER BY column_id",
-                (table.upper(),),
+                f"SELECT column_name, data_type FROM {columns_view} WHERE table_name = :table_name{columns_owner_clause} ORDER BY column_id",
+                params,
             )
             return [ColumnInfo(name=row[0], data_type=row[1], is_primary_key=row[0] in pk_columns) for row in cursor.fetchall()]
         finally:
@@ -209,10 +245,8 @@ class OracleAdapter(DatabaseAdapter):
         """Get stored procedures from Oracle."""
         cursor = conn.cursor()
         try:
-            cursor.execute(
-                "SELECT object_name FROM user_procedures " "WHERE object_type = 'PROCEDURE' ORDER BY object_name"
-            )
-            return [row[0] for row in cursor.fetchall()]
+            cursor.execute("SELECT owner, object_name FROM all_procedures WHERE object_type = 'PROCEDURE' ORDER BY owner, object_name")
+            return [_dictionary_qualified_name(row[0], row[1]) for row in cursor.fetchall()]
         finally:
             cursor.close()
 
@@ -220,16 +254,8 @@ class OracleAdapter(DatabaseAdapter):
         """Get indexes from Oracle."""
         cursor = conn.cursor()
         try:
-            cursor.execute(
-                "SELECT index_name, table_name, uniqueness "
-                "FROM user_indexes "
-                "WHERE index_type != 'LOB' "
-                "ORDER BY table_name, index_name"
-            )
-            return [
-                IndexInfo(name=row[0], table_name=row[1], is_unique=row[2] == "UNIQUE")
-                for row in cursor.fetchall()
-            ]
+            cursor.execute("SELECT owner, index_name, table_owner, table_name, uniqueness FROM all_indexes WHERE index_type != 'LOB' ORDER BY owner, table_owner, table_name, index_name")
+            return [IndexInfo(name=_dictionary_qualified_name(row[0], row[1]), table_name=_dictionary_qualified_name(row[2], row[3]), is_unique=row[4] == "UNIQUE") for row in cursor.fetchall()]
         finally:
             cursor.close()
 
@@ -237,13 +263,8 @@ class OracleAdapter(DatabaseAdapter):
         """Get triggers from Oracle."""
         cursor = conn.cursor()
         try:
-            cursor.execute(
-                "SELECT trigger_name, table_name "
-                "FROM user_triggers "
-                "WHERE base_object_type = 'TABLE' "
-                "ORDER BY table_name, trigger_name"
-            )
-            return [TriggerInfo(name=row[0], table_name=row[1] or "") for row in cursor.fetchall()]
+            cursor.execute("SELECT owner, trigger_name, table_owner, table_name FROM all_triggers WHERE base_object_type = 'TABLE' ORDER BY owner, table_owner, table_name, trigger_name")
+            return [TriggerInfo(name=_dictionary_qualified_name(row[0], row[1]), table_name=_dictionary_qualified_name(row[2], row[3]) if row[3] else "") for row in cursor.fetchall()]
         finally:
             cursor.close()
 
@@ -251,8 +272,8 @@ class OracleAdapter(DatabaseAdapter):
         """Get sequences from Oracle."""
         cursor = conn.cursor()
         try:
-            cursor.execute("SELECT sequence_name FROM user_sequences ORDER BY sequence_name")
-            return [SequenceInfo(name=row[0]) for row in cursor.fetchall()]
+            cursor.execute("SELECT sequence_owner, sequence_name FROM all_sequences ORDER BY sequence_owner, sequence_name")
+            return [SequenceInfo(name=_dictionary_qualified_name(row[0], row[1])) for row in cursor.fetchall()]
         finally:
             cursor.close()
 
@@ -263,28 +284,37 @@ class OracleAdapter(DatabaseAdapter):
         database: str | None = None,
         schema: str | None = None,
     ) -> list[ForeignKeyInfo]:
-        """List outgoing FKs via user_constraints / user_cons_columns.
+        """List outgoing FKs via Oracle's accessible constraint metadata.
 
         Joins each FK's child column (uc) to its parent column (rc) via
         r_constraint_name. Oracle stores identifiers upper-case in the
         dictionary views unless quoted on creation.
         """
+        owner_predicate = "c.owner = :owner_name" if schema else "c.owner = SYS_CONTEXT('USERENV', 'SESSION_USER')"
+        params = {"table_name": table if schema else table.upper()}
+        if schema:
+            params["owner_name"] = schema
         cursor = conn.cursor()
         try:
             cursor.execute(
                 "SELECT c.constraint_name, ucc.position, "
-                "       ucc.column_name, rc.table_name, rcc.column_name "
-                "FROM user_constraints c "
-                "JOIN user_cons_columns ucc "
-                "  ON c.constraint_name = ucc.constraint_name "
-                "JOIN user_constraints rc "
-                "  ON c.r_constraint_name = rc.constraint_name "
-                "JOIN user_cons_columns rcc "
-                "  ON rc.constraint_name = rcc.constraint_name "
+                "       ucc.column_name, rc.table_name, rcc.column_name, "
+                "       c.owner, rc.owner "
+                "FROM all_constraints c "
+                "JOIN all_cons_columns ucc "
+                "  ON c.owner = ucc.owner "
+                "  AND c.constraint_name = ucc.constraint_name "
+                "JOIN all_constraints rc "
+                "  ON c.r_owner = rc.owner "
+                "  AND c.r_constraint_name = rc.constraint_name "
+                "JOIN all_cons_columns rcc "
+                "  ON rc.owner = rcc.owner "
+                "  AND rc.constraint_name = rcc.constraint_name "
                 "  AND ucc.position = rcc.position "
-                "WHERE c.constraint_type = 'R' AND c.table_name = :1 "
+                "WHERE c.constraint_type = 'R' "
+                f"AND {owner_predicate} AND c.table_name = :table_name "
                 "ORDER BY c.constraint_name, ucc.position",
-                (table.upper(),),
+                params,
             )
             return [
                 ForeignKeyInfo(
@@ -292,6 +322,8 @@ class OracleAdapter(DatabaseAdapter):
                     column=row[2],
                     referenced_table=row[3],
                     referenced_column=row[4],
+                    owner_schema=row[5],
+                    referenced_schema=row[6],
                     constraint_name=row[0],
                     ordinal=int(row[1]),
                 )
@@ -308,22 +340,31 @@ class OracleAdapter(DatabaseAdapter):
         schema: str | None = None,
     ) -> list[ForeignKeyInfo]:
         """List FKs from other tables that reference `table`."""
+        owner_predicate = "rc.owner = :owner_name" if schema else "rc.owner = SYS_CONTEXT('USERENV', 'SESSION_USER')"
+        params = {"table_name": table if schema else table.upper()}
+        if schema:
+            params["owner_name"] = schema
         cursor = conn.cursor()
         try:
             cursor.execute(
                 "SELECT c.constraint_name, ucc.position, "
-                "       c.table_name, ucc.column_name, rcc.column_name "
-                "FROM user_constraints c "
-                "JOIN user_cons_columns ucc "
-                "  ON c.constraint_name = ucc.constraint_name "
-                "JOIN user_constraints rc "
-                "  ON c.r_constraint_name = rc.constraint_name "
-                "JOIN user_cons_columns rcc "
-                "  ON rc.constraint_name = rcc.constraint_name "
+                "       c.table_name, ucc.column_name, rcc.column_name, "
+                "       c.owner, rc.owner "
+                "FROM all_constraints c "
+                "JOIN all_cons_columns ucc "
+                "  ON c.owner = ucc.owner "
+                "  AND c.constraint_name = ucc.constraint_name "
+                "JOIN all_constraints rc "
+                "  ON c.r_owner = rc.owner "
+                "  AND c.r_constraint_name = rc.constraint_name "
+                "JOIN all_cons_columns rcc "
+                "  ON rc.owner = rcc.owner "
+                "  AND rc.constraint_name = rcc.constraint_name "
                 "  AND ucc.position = rcc.position "
-                "WHERE c.constraint_type = 'R' AND rc.table_name = :1 "
+                "WHERE c.constraint_type = 'R' "
+                f"AND {owner_predicate} AND rc.table_name = :table_name "
                 "ORDER BY c.table_name, c.constraint_name, ucc.position",
-                (table.upper(),),
+                params,
             )
             return [
                 ForeignKeyInfo(
@@ -331,6 +372,8 @@ class OracleAdapter(DatabaseAdapter):
                     column=row[3],
                     referenced_table=table,
                     referenced_column=row[4],
+                    owner_schema=row[5],
+                    referenced_schema=row[6],
                     constraint_name=row[0],
                     ordinal=int(row[1]),
                 )
@@ -339,16 +382,14 @@ class OracleAdapter(DatabaseAdapter):
         finally:
             cursor.close()
 
-    def get_index_definition(
-        self, conn: Any, index_name: str, table_name: str, database: str | None = None
-    ) -> dict[str, Any]:
+    def get_index_definition(self, conn: Any, index_name: str, table_name: str, database: str | None = None) -> dict[str, Any]:
         """Get detailed information about an Oracle index."""
-        # Get index info
+        owner, bare_index = _split_dictionary_name(index_name)
         cursor = conn.cursor()
         try:
             cursor.execute(
-                "SELECT uniqueness, index_type FROM user_indexes WHERE index_name = :1",
-                (index_name.upper(),),
+                "SELECT uniqueness, index_type FROM all_indexes WHERE index_name = :1 AND owner = COALESCE(:2, SYS_CONTEXT('USERENV', 'SESSION_USER'))",
+                (bare_index, owner),
             )
             row = cursor.fetchone()
             is_unique = row[0] == "UNIQUE" if row else False
@@ -360,9 +401,8 @@ class OracleAdapter(DatabaseAdapter):
         col_cursor = conn.cursor()
         try:
             col_cursor.execute(
-                "SELECT column_name FROM user_ind_columns "
-                "WHERE index_name = :1 ORDER BY column_position",
-                (index_name.upper(),),
+                "SELECT column_name FROM all_ind_columns WHERE index_name = :1 AND index_owner = COALESCE(:2, SYS_CONTEXT('USERENV', 'SESSION_USER')) ORDER BY column_position",
+                (bare_index, owner),
             )
             columns = [row[0] for row in col_cursor.fetchall()]
         finally:
@@ -372,8 +412,8 @@ class OracleAdapter(DatabaseAdapter):
         ddl_cursor = conn.cursor()
         try:
             ddl_cursor.execute(
-                "SELECT DBMS_METADATA.GET_DDL('INDEX', :1) FROM dual",
-                (index_name.upper(),),
+                "SELECT DBMS_METADATA.GET_DDL('INDEX', :1, COALESCE(:2, SYS_CONTEXT('USERENV', 'SESSION_USER'))) FROM dual",
+                (bare_index, owner),
             )
             ddl_row = ddl_cursor.fetchone()
             definition = str(ddl_row[0]) if ddl_row else None
@@ -391,16 +431,14 @@ class OracleAdapter(DatabaseAdapter):
             "definition": definition,
         }
 
-    def get_trigger_definition(
-        self, conn: Any, trigger_name: str, table_name: str, database: str | None = None
-    ) -> dict[str, Any]:
+    def get_trigger_definition(self, conn: Any, trigger_name: str, table_name: str, database: str | None = None) -> dict[str, Any]:
         """Get detailed information about an Oracle trigger."""
+        owner, bare_trigger = _split_dictionary_name(trigger_name)
         cursor = conn.cursor()
         try:
             cursor.execute(
-                "SELECT trigger_type, triggering_event, trigger_body "
-                "FROM user_triggers WHERE trigger_name = :1",
-                (trigger_name.upper(),),
+                "SELECT trigger_type, triggering_event, trigger_body FROM all_triggers WHERE trigger_name = :1 AND owner = COALESCE(:2, SYS_CONTEXT('USERENV', 'SESSION_USER'))",
+                (bare_trigger, owner),
             )
             row = cursor.fetchone()
             if row:
@@ -423,16 +461,14 @@ class OracleAdapter(DatabaseAdapter):
         finally:
             cursor.close()
 
-    def get_sequence_definition(
-        self, conn: Any, sequence_name: str, database: str | None = None
-    ) -> dict[str, Any]:
+    def get_sequence_definition(self, conn: Any, sequence_name: str, database: str | None = None) -> dict[str, Any]:
         """Get detailed information about an Oracle sequence."""
+        owner, bare_sequence = _split_dictionary_name(sequence_name)
         cursor = conn.cursor()
         try:
             cursor.execute(
-                "SELECT min_value, max_value, increment_by, cycle_flag, last_number "
-                "FROM user_sequences WHERE sequence_name = :1",
-                (sequence_name.upper(),),
+                "SELECT min_value, max_value, increment_by, cycle_flag, last_number FROM all_sequences WHERE sequence_name = :1 AND sequence_owner = COALESCE(:2, SYS_CONTEXT('USERENV', 'SESSION_USER'))",
+                (bare_sequence, owner),
             )
             row = cursor.fetchone()
             if row:
@@ -464,8 +500,9 @@ class OracleAdapter(DatabaseAdapter):
         return f'"{escaped}"'
 
     def build_select_query(self, table: str, limit: int, database: str | None = None, schema: str | None = None) -> str:
-        """Build SELECT query with FETCH FIRST for Oracle 12c+. Schema parameter is ignored."""
-        return f'SELECT * FROM "{table}" FETCH FIRST {limit} ROWS ONLY'
+        """Build a schema-aware SELECT query with Oracle 12c+ pagination."""
+        qualified = self.catalog_qualified_name(database, schema, table)
+        return f"SELECT * FROM {qualified} FETCH FIRST {limit} ROWS ONLY"
 
     def build_filtered_select_query(self, table: str, column: str, value: Any, limit: int, database: str | None = None, schema: str | None = None) -> str:
         qualified = self.catalog_qualified_name(database, schema, table)

--- a/sqlit/domains/connections/providers/oracle_legacy/adapter.py
+++ b/sqlit/domains/connections/providers/oracle_legacy/adapter.py
@@ -71,8 +71,9 @@ class OracleLegacyAdapter(OracleAdapter):
         return super().connect(config)
 
     def build_select_query(self, table: str, limit: int, database: str | None = None, schema: str | None = None) -> str:
-        """Build SELECT query with ROWNUM for Oracle 11g. Schema parameter is ignored."""
-        return f'SELECT * FROM (SELECT * FROM "{table}") WHERE ROWNUM <= {limit}'
+        """Build a schema-aware SELECT query with Oracle 11g ROWNUM pagination."""
+        qualified = self.catalog_qualified_name(database, schema, table)
+        return f"SELECT * FROM (SELECT * FROM {qualified}) WHERE ROWNUM <= {limit}"
 
     def build_filtered_select_query(self, table: str, column: str, value: Any, limit: int, database: str | None = None, schema: str | None = None) -> str:
         qualified = self.catalog_qualified_name(database, schema, table)

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -168,6 +168,81 @@ class TestOracleIntegration(BaseDatabaseTests):
         assert result.returncode == 0
         assert "clob value ok" in result.stdout
 
+    def test_schema_introspection_includes_granted_cross_schema_tables(self, oracle_db):
+        """Tables granted from another schema must appear with usable columns."""
+        import os
+
+        import oracledb
+
+        from sqlit.domains.connections.providers.oracle.adapter import OracleAdapter
+        from tests.fixtures.oracle import (
+            ORACLE_HOST,
+            ORACLE_PASSWORD,
+            ORACLE_PORT,
+            ORACLE_USER,
+        )
+
+        owner = "ISSUE295_OWNER"
+        table = "SHARED_CUSTOMERS"
+        dsn = f"{ORACLE_HOST}:{ORACLE_PORT}/{oracle_db}"
+        admin = oracledb.connect(
+            user="system",
+            password=os.environ.get("ORACLE_ADMIN_PASSWORD", ORACLE_PASSWORD),
+            dsn=dsn,
+        )
+        try:
+            cursor = admin.cursor()
+            try:
+                try:
+                    cursor.execute(f"DROP USER {owner} CASCADE")
+                except oracledb.DatabaseError:
+                    pass
+                cursor.execute(f'CREATE USER {owner} IDENTIFIED BY "Issue295Password123!"')
+                cursor.execute(f"ALTER USER {owner} QUOTA UNLIMITED ON USERS")
+                cursor.execute(f"CREATE TABLE {owner}.{table} (id NUMBER PRIMARY KEY, name VARCHAR2(50))")
+                cursor.execute(f"CREATE INDEX {owner}.IX_SHARED_NAME ON {owner}.{table} (name)")
+                cursor.execute(f"CREATE TRIGGER {owner}.TRG_SHARED BEFORE INSERT ON {owner}.{table} FOR EACH ROW BEGIN NULL; END;")
+                cursor.execute(f"CREATE SEQUENCE {owner}.SHARED_SEQ START WITH 1")
+                cursor.execute(f"CREATE PROCEDURE {owner}.REFRESH_SHARED AS BEGIN NULL; END;")
+                cursor.execute(f"GRANT SELECT ON {owner}.{table} TO {ORACLE_USER}")
+                cursor.execute(f"GRANT SELECT ON {owner}.SHARED_SEQ TO {ORACLE_USER}")
+                cursor.execute(f"GRANT EXECUTE ON {owner}.REFRESH_SHARED TO {ORACLE_USER}")
+                admin.commit()
+
+                user_conn = oracledb.connect(
+                    user=ORACLE_USER,
+                    password=ORACLE_PASSWORD,
+                    dsn=dsn,
+                )
+                try:
+                    adapter = OracleAdapter()
+                    assert (owner, table) in adapter.get_tables(user_conn)
+                    columns = adapter.get_columns(user_conn, table, schema=owner)
+                    assert [(column.name, column.is_primary_key) for column in columns] == [
+                        ("ID", True),
+                        ("NAME", False),
+                    ]
+                    index = next(item for item in adapter.get_indexes(user_conn) if item.name == f"{owner}.IX_SHARED_NAME")
+                    assert index.table_name == f"{owner}.{table}"
+                    assert adapter.get_index_definition(user_conn, index.name, index.table_name)["columns"] == ["NAME"]
+                    trigger = next(item for item in adapter.get_triggers(user_conn) if item.name == f"{owner}.TRG_SHARED")
+                    assert adapter.get_trigger_definition(user_conn, trigger.name, trigger.table_name)["event"] == "INSERT"
+                    sequence = next(item for item in adapter.get_sequences(user_conn) if item.name == f"{owner}.SHARED_SEQ")
+                    assert adapter.get_sequence_definition(user_conn, sequence.name)["increment"] == 1
+                    assert f"{owner}.REFRESH_SHARED" in adapter.get_procedures(user_conn)
+                finally:
+                    user_conn.close()
+            finally:
+                cursor.close()
+        finally:
+            try:
+                cursor = admin.cursor()
+                cursor.execute(f"DROP USER {owner} CASCADE")
+                admin.commit()
+                cursor.close()
+            finally:
+                admin.close()
+
     def test_delete_oracle_connection(self, oracle_db, cli_runner):
         """Test deleting an Oracle connection."""
         from .conftest import ORACLE_HOST, ORACLE_PASSWORD, ORACLE_PORT, ORACLE_USER

--- a/tests/unit/test_oracle_adapter.py
+++ b/tests/unit/test_oracle_adapter.py
@@ -9,6 +9,164 @@ import pytest
 from tests.helpers import ConnectionConfig
 
 
+class TestOracleAdapterSchemaIntrospection:
+    """Regression coverage for issue #295."""
+
+    def test_get_tables_returns_all_accessible_schema_owners(self):
+        from sqlit.domains.connections.providers.oracle.adapter import OracleAdapter
+
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [
+            ("COMMON", "CUSTOMERS"),
+            ("REPORTING", "MONTHLY_TOTALS"),
+        ]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        tables = OracleAdapter().get_tables(conn)
+
+        assert tables == [
+            ("COMMON", "CUSTOMERS"),
+            ("REPORTING", "MONTHLY_TOTALS"),
+        ]
+        assert "all_tables" in cursor.execute.call_args.args[0].lower()
+
+    def test_get_views_returns_all_accessible_schema_owners(self):
+        from sqlit.domains.connections.providers.oracle.adapter import OracleAdapter
+
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [("COMMON", "ACTIVE_CUSTOMERS")]
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        assert OracleAdapter().get_views(conn) == [("COMMON", "ACTIVE_CUSTOMERS")]
+        assert "all_views" in cursor.execute.call_args.args[0].lower()
+
+    def test_get_columns_scopes_cross_schema_table_and_primary_key(self):
+        from sqlit.domains.connections.providers.oracle.adapter import OracleAdapter
+
+        pk_cursor = MagicMock()
+        pk_cursor.fetchall.return_value = [("ID",)]
+        columns_cursor = MagicMock()
+        columns_cursor.fetchall.return_value = [
+            ("ID", "NUMBER"),
+            ("NAME", "VARCHAR2"),
+        ]
+        conn = MagicMock()
+        conn.cursor.side_effect = [pk_cursor, columns_cursor]
+
+        columns = OracleAdapter().get_columns(conn, "Customers", schema="Reporting")
+
+        assert [(column.name, column.is_primary_key) for column in columns] == [
+            ("ID", True),
+            ("NAME", False),
+        ]
+        pk_sql = pk_cursor.execute.call_args.args[0].lower()
+        columns_sql = columns_cursor.execute.call_args.args[0].lower()
+        assert "all_constraints" in pk_sql
+        assert "all_cons_columns" in pk_sql
+        assert "all_tab_columns" in columns_sql
+        expected_params = {"table_name": "Customers", "owner_name": "Reporting"}
+        assert pk_cursor.execute.call_args.args[1] == expected_params
+        assert columns_cursor.execute.call_args.args[1] == expected_params
+
+    def test_legacy_select_qualifies_cross_schema_table(self):
+        from sqlit.domains.connections.providers.oracle_legacy.adapter import (
+            OracleLegacyAdapter,
+        )
+
+        query = OracleLegacyAdapter().build_select_query("CUSTOMERS", 100, schema="COMMON")
+
+        assert query == ('SELECT * FROM (SELECT * FROM "COMMON"."CUSTOMERS") WHERE ROWNUM <= 100')
+
+    def test_select_qualifies_cross_schema_table(self):
+        from sqlit.domains.connections.providers.oracle.adapter import OracleAdapter
+
+        query = OracleAdapter().build_select_query("Customers", 100, schema="Reporting")
+
+        assert query == ('SELECT * FROM "Reporting"."Customers" FETCH FIRST 100 ROWS ONLY')
+
+    @pytest.mark.parametrize(
+        ("method", "dictionary_view", "rows", "expected"),
+        [
+            ("get_procedures", "all_procedures", [("REPORTING", "REFRESH_TOTALS")], ["REPORTING.REFRESH_TOTALS"]),
+            ("get_indexes", "all_indexes", [("INDEX_OWNER", "IX_TOTALS", "TABLE_OWNER", "MONTHLY_TOTALS", "UNIQUE")], None),
+            ("get_triggers", "all_triggers", [("TRIGGER_OWNER", "TRG_TOTALS", "TABLE_OWNER", "MONTHLY_TOTALS")], None),
+            ("get_sequences", "all_sequences", [("REPORTING", "TOTALS_SEQ")], None),
+        ],
+    )
+    def test_auxiliary_objects_include_accessible_schema_owners(self, method, dictionary_view, rows, expected):
+        from sqlit.domains.connections.providers.oracle.adapter import OracleAdapter
+
+        cursor = MagicMock()
+        cursor.fetchall.return_value = rows
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        result = getattr(OracleAdapter(), method)(conn)
+
+        assert dictionary_view in cursor.execute.call_args.args[0].lower()
+        if expected is not None:
+            assert result == expected
+        else:
+            assert result[0].name.endswith("." + rows[0][1])
+            if method in {"get_indexes", "get_triggers"}:
+                assert result[0].table_name == "TABLE_OWNER.MONTHLY_TOTALS"
+
+    @pytest.mark.parametrize(
+        ("method", "dictionary_view", "args"),
+        [
+            ("get_index_definition", "all_indexes", ("REPORTING.IX_TOTALS", "REPORTING.MONTHLY_TOTALS")),
+            ("get_trigger_definition", "all_triggers", ("REPORTING.TRG_TOTALS", "REPORTING.MONTHLY_TOTALS")),
+            ("get_sequence_definition", "all_sequences", ("REPORTING.TOTALS_SEQ",)),
+        ],
+    )
+    def test_auxiliary_definition_uses_qualified_owner(self, method, dictionary_view, args):
+        from sqlit.domains.connections.providers.oracle.adapter import OracleAdapter
+
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = []
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        getattr(OracleAdapter(), method)(conn, *args)
+
+        calls = [call.args for call in cursor.execute.call_args_list]
+        assert any(dictionary_view in sql.lower() for sql, *_ in calls)
+        assert any("REPORTING" in repr(params) for _, params in calls)
+
+    def test_quoted_dotted_auxiliary_owner_round_trips(self):
+        from sqlit.domains.connections.providers.oracle.adapter import (
+            OracleAdapter,
+            _dictionary_qualified_name,
+        )
+
+        qualified = _dictionary_qualified_name("REPORT.ING", "IX.A")
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = []
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        OracleAdapter().get_index_definition(conn, qualified, "T")
+
+        assert cursor.execute.call_args_list[0].args[1] == ("IX.A", "REPORT.ING")
+
+    def test_unqualified_auxiliary_definition_preserves_oracle_uppercase_lookup(self):
+        from sqlit.domains.connections.providers.oracle.adapter import OracleAdapter
+
+        cursor = MagicMock()
+        cursor.fetchone.return_value = None
+        cursor.fetchall.return_value = []
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+
+        OracleAdapter().get_sequence_definition(conn, "test_sequence")
+
+        assert cursor.execute.call_args.args[1] == ("TEST_SEQUENCE", None)
+
+
 class TestOracleAdapterRole:
     """Test Oracle adapter handles role/mode parameter correctly."""
 
@@ -182,19 +340,14 @@ class TestOracleAdapterConnectionType:
                 options={
                     "oracle_connection_type": "service_name",
                     "oracle_protocol": "tcps",
-                    "oracle_easy_connect_parameters": (
-                        "ssl_server_dn_match=no&retry_count=3"
-                    ),
+                    "oracle_easy_connect_parameters": ("ssl_server_dn_match=no&retry_count=3"),
                 },
             )
 
             adapter.connect(config)
 
             call_kwargs = mock_oracledb.connect.call_args.kwargs
-            assert call_kwargs["dsn"] == (
-                "tcps://localhost:1521/service-name.com"
-                "?ssl_server_dn_match=no&retry_count=3"
-            )
+            assert call_kwargs["dsn"] == ("tcps://localhost:1521/service-name.com?ssl_server_dn_match=no&retry_count=3")
 
     def test_connect_easy_connect_parameters_accept_leading_question_mark(self):
         """Users may paste Easy Connect parameters with their separator."""
@@ -216,9 +369,7 @@ class TestOracleAdapterConnectionType:
 
             OracleAdapter().connect(config)
 
-            assert mock_oracledb.connect.call_args.kwargs["dsn"] == (
-                "localhost:1521/XEPDB1?expire_time=2"
-            )
+            assert mock_oracledb.connect.call_args.kwargs["dsn"] == ("localhost:1521/XEPDB1?expire_time=2")
 
     def test_connect_rejects_unknown_oracle_protocol(self):
         """Configs outside the schema must not silently discard bad protocols."""
@@ -268,18 +419,14 @@ class TestOracleAdapterConnectionType:
             OracleAdapter().connect(config)
 
             mock_oracledb.makedsn.assert_called_once_with("localhost", 1521, sid="ORCL")
-            assert mock_oracledb.connect.call_args.kwargs["dsn"] is (
-                mock_oracledb.makedsn.return_value
-            )
+            assert mock_oracledb.connect.call_args.kwargs["dsn"] is (mock_oracledb.makedsn.return_value)
 
     def test_tcps_easy_connect_dsn_parses_in_real_driver(self):
         """The issue #261 DSN must be accepted by python-oracledb itself."""
         oracledb = pytest.importorskip("oracledb")
         params = oracledb.ConnectParams()
 
-        params.parse_connect_string(
-            "tcps://localhost:1521/service-name.com?ssl_server_dn_match=no"
-        )
+        params.parse_connect_string("tcps://localhost:1521/service-name.com?ssl_server_dn_match=no")
 
         assert params.protocol == "tcps"
         assert params.host == "localhost"
@@ -421,6 +568,4 @@ class TestOracleAdapterConnectionType:
             adapter.connect(config)
 
         message = str(exc_info.value)
-        assert "DPY-4027" not in message, (
-            f"issue #106 regression: SID DSN rejected at parse step: {message}"
-        )
+        assert "DPY-4027" not in message, f"issue #106 regression: SID DSN rejected at parse step: {message}"


### PR DESCRIPTION
## Summary

- discover accessible Oracle objects through owner-aware `ALL_*` dictionary views
- preserve schema ownership for tables, views, columns, keys, indexes, triggers, sequences, and procedures
- qualify generated queries for both modern and legacy Oracle adapters
- handle quoted/dotted owners and differing index/trigger versus table owners
- add unit and live cross-schema Oracle regressions

Fixes #295.

## Validation

- Oracle adapter unit tests: 29 passed
- full live Oracle integration suite: 32 passed
- second-owner live fixture covered granted tables, indexes, triggers, sequences, and procedures
- Ruff and structured autoreview: clean

Synonyms remain separate feature scope because sqlit currently has no synonym capability/model/explorer target-resolution path.