### PR TITLE
Update cursor tests for double blank-line separators

### DIFF
--- a/tests/unit/test_single_statement_execution.py
+++ b/tests/unit/test_single_statement_execution.py
@@ -17,10 +17,10 @@ from sqlit.domains.query.ui.mixins.query_execution import QueryExecutionMixin
         ("SELECT 1; SELECT 2; SELECT 3", 0, 3, "SELECT 1"),
         ("SELECT 1; SELECT 2; SELECT 3", 0, 12, "SELECT 2"),
         ("SELECT ';'; SELECT 2", 0, 8, "SELECT ';'"),
-        # Blank-line separated statements (no semicolons) should work like semicolon-separated
-        ("SELECT 1\n\nSELECT 2", 0, 3, "SELECT 1"),
-        ("SELECT 1\n\nSELECT 2", 2, 3, "SELECT 2"),
-        ("SELECT *\nFROM users\n\nSELECT 2", 1, 5, "SELECT *\nFROM users"),
+        # Two-blank-line separated statements (no semicolons) work like semicolon-separated
+        ("SELECT 1\n\n\nSELECT 2", 0, 3, "SELECT 1"),
+        ("SELECT 1\n\n\nSELECT 2", 3, 3, "SELECT 2"),
+        ("SELECT *\nFROM users\n\n\nSELECT 2", 1, 5, "SELECT *\nFROM users"),
         # Semicolon-separated with blank lines
         ("SELECT 1;\n\nSELECT 2", 2, 3, "SELECT 2"),
         ("SELECT *\nFROM users;\nSELECT 2", 1, 5, "SELECT *\nFROM users"),


### PR DESCRIPTION
## Summary

- update statement-at-cursor regressions to use the two-blank-line separator introduced in #306
- correct the second statement cursor row after the additional empty line

## Validation

- multi-statement and single-statement suites: 45 passed

Follow-up to #306.