### PR TITLE
Include PostgreSQL foreign tables in discovery

### DIFF
--- a/sqlit/domains/connections/providers/postgresql/base.py
+++ b/sqlit/domains/connections/providers/postgresql/base.py
@@ -71,7 +71,7 @@ class PostgresBaseAdapter(CursorBasedAdapter):
         cursor = conn.cursor()
         cursor.execute(
             "SELECT table_schema, table_name FROM information_schema.tables "
-            "WHERE table_type = 'BASE TABLE' "
+            "WHERE table_type IN ('BASE TABLE', 'FOREIGN') "
             "AND table_schema NOT IN ('pg_catalog', 'information_schema') "
             "ORDER BY table_schema, table_name"
         )

--- a/tests/unit/test_postgres_fdw.py
+++ b/tests/unit/test_postgres_fdw.py
@@ -1,0 +1,23 @@
+"""Regression coverage for PostgreSQL foreign-table discovery."""
+
+from unittest.mock import MagicMock
+
+from sqlit.domains.connections.providers.postgresql.adapter import PostgreSQLAdapter
+
+
+def test_get_tables_requests_base_and_foreign_tables() -> None:
+    connection = MagicMock()
+    cursor = connection.cursor.return_value
+    cursor.fetchall.return_value = [
+        ("public", "local_users"),
+        ("remote", "foreign_orders"),
+    ]
+
+    tables = PostgreSQLAdapter().get_tables(connection)
+
+    assert tables == [
+        ("public", "local_users"),
+        ("remote", "foreign_orders"),
+    ]
+    query = cursor.execute.call_args.args[0]
+    assert "table_type IN ('BASE TABLE', 'FOREIGN')" in query


### PR DESCRIPTION
## Summary

- include PostgreSQL `FOREIGN` tables alongside ordinary base tables
- keep foreign tables in the existing Tables explorer folder
- add a regression for the information-schema query

Fixes #259.

## Validation

- regression failed before the fix and passes afterward
- live `postgres_fdw` loopback table was discovered, introspected, and queried successfully
- Ruff and structured autoreview: clean