### PR TITLE
Add suspend command

### DIFF
--- a/sqlit/domains/shell/app/main.py
+++ b/sqlit/domains/shell/app/main.py
@@ -698,6 +698,10 @@ class SSMSTUI(
                 self.exit()
             return
 
+        if cmd in {"s", "suspend"}:
+            self.action_suspend_process()
+            return
+
         command_actions = {
             "help": "show_help",
             "h": "show_help",
@@ -799,6 +803,7 @@ class SSMSTUI(
             ("General", ":version, :ver", "Show version and git hash", ""),
             ("General", ":help, :h", "Show keyboard shortcuts", ""),
             ("General", ":q, :quit, :exit", "Quit sqlit", ""),
+            ("General", ":s, :suspend", "Suspend sqlit; resume with fg", "Unix only"),
             ("Connection", ":connect, :c", "Open connection picker", ""),
             ("Connection", ":disconnect, :dc", "Disconnect from current server", ""),
             (

--- a/tests/ui/test_suspend_command.py
+++ b/tests/ui/test_suspend_command.py
@@ -1,0 +1,43 @@
+"""Tests for the :s / :suspend command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from sqlit.domains.shell.app.main import SSMSTUI
+
+from .mocks import MockConnectionStore, MockSettingsStore, build_test_services
+
+
+def _make_app() -> SSMSTUI:
+    return SSMSTUI(
+        services=build_test_services(
+            connection_store=MockConnectionStore(),
+            settings_store=MockSettingsStore({"theme": "tokyo-night"}),
+        )
+    )
+
+
+@pytest.mark.parametrize("command", ["s", "suspend", "S", " SUSPEND "])
+def test_suspend_command_uses_textual_process_suspension(command: str) -> None:
+    app = _make_app()
+    app.action_suspend_process = MagicMock()  # type: ignore[method-assign]
+
+    app._run_command(command)
+
+    app.action_suspend_process.assert_called_once_with()
+
+
+def test_suspend_command_is_listed() -> None:
+    app = _make_app()
+    captured: list[tuple[list[str], list[tuple[str, str, str, str]]]] = []
+    app._replace_results_table = (  # type: ignore[method-assign]
+        lambda columns, rows: captured.append((columns, rows))
+    )
+
+    app._show_command_list()
+
+    _columns, rows = captured[0]
+    assert ("General", ":s, :suspend", "Suspend sqlit; resume with fg", "Unix only") in rows


### PR DESCRIPTION
## Summary

- add `:s` and `:suspend` commands
- delegate suspension and terminal restoration to Textual’s built-in `action_suspend_process()`
- document resuming with `fg` and the Unix-only limitation in `:commands`
- add command dispatch and command-list regressions

Fixes #258.

## Validation

- focused command tests: 6 passed
- aliases, case normalization, dispatch, and command-list visibility covered
- structured autoreview: clean