### PR TITLE
Fix UUID result rendering with PyArrow 24+

### DIFF
--- a/sqlit/domains/query/ui/mixins/query_results.py
+++ b/sqlit/domains/query/ui/mixins/query_results.py
@@ -8,6 +8,7 @@ from typing import Any
 from sqlit.shared.core.utils import format_duration_ms
 from sqlit.shared.ui.protocols import QueryMixinHost
 from sqlit.shared.ui.widgets import SqlitDataTable
+from sqlit.shared.ui.widgets_tables import normalize_arrow_value
 
 from .query_constants import MAX_COLUMN_CONTENT_WIDTH, MAX_RENDER_ROWS
 
@@ -258,13 +259,17 @@ class QueryResultsMixin:
             if has_decimal_in_initial:
                 decimal_types = self._get_decimal_column_types(rows)
                 if decimal_types:
-                    from textual_fastdatatable.backend import ArrowBackend
                     import pyarrow as pa
+                    from textual_fastdatatable.backend import ArrowBackend
 
                     arrays = []
                     coerce_to_str_columns = set()
                     for idx, _name in enumerate(columns):
-                        values = [row[idx] for row in initial_rows] if initial_rows else []
+                        values = (
+                            [normalize_arrow_value(row[idx]) for row in initial_rows]
+                            if initial_rows
+                            else []
+                        )
                         col_type = decimal_types.get(idx)
                         try:
                             if col_type is not None:

--- a/sqlit/shared/ui/widgets_tables.py
+++ b/sqlit/shared/ui/widgets_tables.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Any
+from uuid import UUID
 
 from rich.align import Align
 from rich.errors import MarkupError
@@ -18,6 +20,33 @@ from textual.strip import Strip
 from textual_fastdatatable import DataTable as FastDataTable
 
 
+def normalize_arrow_value(value: Any) -> Any:
+    """Keep Arrow from inferring its binary UUID extension type."""
+    return str(value) if isinstance(value, UUID) else value
+
+
+def _stringify_uuid_rows(rows: Iterable[Iterable[Any]]) -> list[tuple[Any, ...]]:
+    return [tuple(normalize_arrow_value(value) for value in row) for row in rows]
+
+
+def _stringify_uuid_data(data: Any) -> Any:
+    if isinstance(data, dict):
+        return {
+            name: [normalize_arrow_value(value) for value in values]
+            if isinstance(values, (list, tuple))
+            else values
+            for name, values in data.items()
+        }
+    if isinstance(data, (list, tuple)):
+        return [
+            tuple(normalize_arrow_value(value) for value in row)
+            if isinstance(row, (list, tuple))
+            else row
+            for row in data
+        ]
+    return data
+
+
 class SqlitDataTable(FastDataTable):
     """FastDataTable with correct header behavior when show_header is False.
 
@@ -26,6 +55,12 @@ class SqlitDataTable(FastDataTable):
 
     # Track if a manual tooltip is being shown (via 'v' key)
     _manual_tooltip_active: bool = False
+
+    def __init__(self, *, data: Any | None = None, **kwargs: Any) -> None:
+        super().__init__(data=_stringify_uuid_data(data), **kwargs)
+
+    def add_rows(self, rows: Iterable[Iterable[Any]]) -> list[int]:
+        return super().add_rows(_stringify_uuid_rows(rows))
 
     def _set_tooltip_from_cell_at(self, coordinate: Any) -> None:
         """Override to disable hover tooltips entirely."""

--- a/tests/ui/test_uuid_fastdatatable.py
+++ b/tests/ui/test_uuid_fastdatatable.py
@@ -1,0 +1,75 @@
+"""Regression coverage for UUID result values with PyArrow 24+."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from uuid import UUID
+
+import pytest
+from textual.coordinate import Coordinate
+
+from sqlit.domains.shell.app.main import SSMSTUI
+from sqlit.shared.ui.widgets_tables import SqlitDataTable
+
+from .mocks import (
+    MockConnectionStore,
+    MockSettingsStore,
+    build_test_services,
+    create_test_connection,
+)
+
+_INVALID_UTF8_UUID = UUID("a0000000-0000-0000-0000-000000000000")
+
+
+def test_uuid_column_is_stringified_before_arrow_measurement() -> None:
+    table = SqlitDataTable(
+        data={"Id": [_INVALID_UTF8_UUID]},
+        column_labels=["Id"],
+    )
+
+    assert table.backend is not None
+    assert table.backend.column_content_widths == [36]
+    assert table.get_cell_at(Coordinate(0, 0)) == str(_INVALID_UTF8_UUID)
+
+
+def test_incrementally_added_uuid_is_stringified() -> None:
+    table = SqlitDataTable(data={"Id": ["initial"]}, column_labels=["Id"])
+
+    table.add_rows([(_INVALID_UTF8_UUID,)])
+
+    assert table.backend is not None
+    assert table.backend.column_content_widths == [36]
+    assert table.get_cell_at(Coordinate(1, 0)) == str(_INVALID_UTF8_UUID)
+
+
+@pytest.mark.asyncio
+async def test_decimal_incremental_backend_stringifies_uuid_column() -> None:
+    connection = create_test_connection("test-db", "sqlite")
+    services = build_test_services(
+        connection_store=MockConnectionStore([connection]),
+        settings_store=MockSettingsStore({"theme": "tokyo-night"}),
+    )
+    app = SSMSTUI(services=services)
+    rows = [
+        (index, Decimal(f"{index}.25"), _INVALID_UTF8_UUID)
+        for index in range(1, 202)
+    ]
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await app._display_query_results(
+            columns=["id", "amount", "guid"],
+            rows=rows,
+            row_count=len(rows),
+            truncated=False,
+            elapsed_ms=0,
+        )
+        for _ in range(3):
+            await pilot.pause(0.05)
+
+        assert app.results_table.row_count == len(rows)
+        assert app.results_table.backend is not None
+        assert app.results_table.backend.column_content_widths[2] == 36
+        assert app.results_table.get_cell_at(Coordinate(0, 2)) == str(
+            _INVALID_UTF8_UUID
+        )


### PR DESCRIPTION
## Summary

- render UUID result values as strings before they reach Arrow
- cover direct and incremental result rendering, including Decimal columns

Fixes #315.

## Validation

- PyArrow 25.0.1 regression suite: 7 passed
- full unit/UI suite: 1,527 passed, 2 skipped
- Ruff, MyPy, and structured autoreview: clean
