### PR TITLE
Add Azure Entra CLI authentication for PostgreSQL

### DIFF
--- a/sqlit/cli.py
+++ b/sqlit/cli.py
@@ -727,6 +727,11 @@ def main() -> int:
         choices=[t.value for t in AuthType],
         help="Authentication type (SQL Server only)",
     )
+    edit_parser.add_argument(
+        "--postgres-auth-method",
+        choices=["password", "azure_entra_cli"],
+        help="PostgreSQL authentication method",
+    )
     edit_parser.add_argument("--file-path", help="Database file path (SQLite only)")
     edit_parser.add_argument("--password-command", dest="password_command", help="Shell command to retrieve the database password")
     edit_parser.add_argument("--ssh-password-command", dest="ssh_password_command", help="Shell command to retrieve the SSH password")

--- a/sqlit/core/connection_manager.py
+++ b/sqlit/core/connection_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 from typing import Any
 
@@ -32,19 +33,38 @@ class ConnectionManager:
             return config
 
         service = self._services.credentials_service
-        if endpoint and endpoint.password is None and uses_db_password(config):
+        if endpoint and endpoint.password is None and not endpoint.password_command and uses_db_password(config):
             password = service.get_password(config.name)
             if password is not None:
                 endpoint.password = password
-        if config.tunnel and config.tunnel.password is None:
+        if config.tunnel and config.tunnel.password is None and not config.tunnel.password_command:
             ssh_password = service.get_ssh_password(config.name)
             if ssh_password is not None:
                 config.tunnel.password = ssh_password
         return config
 
+    def _resolve_dynamic_credentials(self, config: ConnectionConfig) -> ConnectionConfig:
+        """Resolve commands on a copy so short-lived secrets are not persisted."""
+        from sqlit.domains.connections.domain.password_command import (
+            run_password_command,
+        )
+        from sqlit.domains.connections.providers.config_service import (
+            normalize_connection_config,
+        )
+
+        resolved = normalize_connection_config(copy.deepcopy(config))
+        endpoint = resolved.tcp_endpoint
+        if endpoint and endpoint.password is None and endpoint.password_command and resolved.db_type != "postgresql":
+            # PostgreSQL resolves this at the adapter boundary so reconnects and
+            # database switches always fetch a fresh short-lived token.
+            endpoint.password = run_password_command(endpoint.password_command)
+        if resolved.tunnel and resolved.tunnel.auth_type == "password" and resolved.tunnel.password is None and resolved.tunnel.password_command:
+            resolved.tunnel.password = run_password_command(resolved.tunnel.password_command)
+        return resolved
+
     def connect(self, config: ConnectionConfig) -> Any:
         """Create a session for the given config."""
-        return self._services.session_factory(config)
+        return self._services.session_factory(self._resolve_dynamic_credentials(config))
 
     def test_connection(self, config: ConnectionConfig) -> ConnectionTestResult:
         """Test a connection without mutating UI state."""
@@ -55,13 +75,14 @@ class ConnectionManager:
         error: Exception | None = None
 
         try:
-            tunnel, host, port = self._services.tunnel_factory(config)
+            resolved = self._resolve_dynamic_credentials(config)
+            tunnel, host, port = self._services.tunnel_factory(resolved)
             if tunnel:
-                connect_config = config.with_endpoint(host=host, port=str(port))
+                connect_config = resolved.with_endpoint(host=host, port=str(port))
             else:
-                connect_config = config
+                connect_config = resolved
 
-            provider = self._services.provider_factory(config.db_type)
+            provider = self._services.provider_factory(resolved.db_type)
             conn = provider.connection_factory.connect(connect_config)
             conn.close()
         except Exception as exc:

--- a/sqlit/domains/connections/app/persist_utils.py
+++ b/sqlit/domains/connections/app/persist_utils.py
@@ -22,12 +22,16 @@ def build_persist_connections(
     persist_connections = copy.deepcopy(connections)
     for conn in persist_connections:
         endpoint = conn.tcp_endpoint
-        if endpoint and endpoint.password is None:
+        if endpoint and endpoint.password is None and not endpoint.password_command:
             stored = credentials_service.get_password(conn.name)
             if stored is not None:
                 endpoint.password = stored
 
-        if conn.tunnel and conn.tunnel.password is None:
+        if (
+            conn.tunnel
+            and conn.tunnel.password is None
+            and not conn.tunnel.password_command
+        ):
             stored_ssh = credentials_service.get_ssh_password(conn.name)
             if stored_ssh is not None:
                 conn.tunnel.password = stored_ssh

--- a/sqlit/domains/connections/cli/commands.py
+++ b/sqlit/domains/connections/cli/commands.py
@@ -277,6 +277,12 @@ def cmd_connection_edit(args: Any, *, services: AppServices | None = None) -> in
             valid_types = ", ".join(t.value for t in AuthType)
             print(f"Error: Invalid auth type '{args.auth_type}'. Valid types: {valid_types}")
             return 1
+    postgres_auth_method = getattr(args, "postgres_auth_method", None)
+    if postgres_auth_method is not None:
+        if conn.db_type != "postgresql":
+            print("Error: --postgres-auth-method is only valid for PostgreSQL.")
+            return 1
+        conn.set_option("postgres_auth_method", postgres_auth_method)
     if endpoint:
         if args.username is not None:
             endpoint.username = args.username
@@ -286,6 +292,24 @@ def cmd_connection_edit(args: Any, *, services: AppServices | None = None) -> in
     password_command = getattr(args, "password_command", None)
     if password_command is not None and endpoint:
         endpoint.password_command = password_command or None
+        if conn.db_type == "postgresql":
+            from sqlit.domains.connections.providers.postgresql.auth import (
+                AZURE_ENTRA_PASSWORD_COMMAND,
+                POSTGRES_AUTH_AZURE_ENTRA_CLI,
+            )
+
+            if password_command == AZURE_ENTRA_PASSWORD_COMMAND:
+                conn.set_option("postgres_auth_method", POSTGRES_AUTH_AZURE_ENTRA_CLI)
+                postgres_auth_method = POSTGRES_AUTH_AZURE_ENTRA_CLI
+
+    if conn.db_type == "postgresql":
+        from sqlit.domains.connections.providers.config_service import (
+            normalize_connection_config,
+        )
+
+        conn = normalize_connection_config(conn)
+        connections[conn_idx] = conn
+        endpoint = conn.tcp_endpoint
 
     ssh_password_command = getattr(args, "ssh_password_command", None)
     if ssh_password_command is not None and conn.tunnel:

--- a/sqlit/domains/connections/cli/helpers.py
+++ b/sqlit/domains/connections/cli/helpers.py
@@ -15,11 +15,7 @@ from sqlit.domains.connections.providers.schema_helpers import ConnectionSchema,
 def _get_connection_arg_names() -> set[str]:
     from sqlit.domains.connections.providers.catalog import get_all_schemas
 
-    names = {
-        field.name
-        for schema in get_all_schemas().values()
-        for field in schema.fields
-    }
+    names = {field.name for schema in get_all_schemas().values() for field in schema.fields}
     names.add("host")
     return names
 
@@ -119,6 +115,14 @@ def build_connection_config_from_args(
     password_command = getattr(args, "password_command", None)
     if password_command:
         config_values["password_command"] = password_command
+        if schema.db_type == "postgresql":
+            from sqlit.domains.connections.providers.postgresql.auth import (
+                AZURE_ENTRA_PASSWORD_COMMAND,
+                POSTGRES_AUTH_AZURE_ENTRA_CLI,
+            )
+
+            if password_command == AZURE_ENTRA_PASSWORD_COMMAND:
+                config_values["postgres_auth_method"] = POSTGRES_AUTH_AZURE_ENTRA_CLI
     ssh_password_command = getattr(args, "ssh_password_command", None)
     if ssh_password_command:
         config_values["ssh_password_command"] = ssh_password_command

--- a/sqlit/domains/connections/domain/passwords.py
+++ b/sqlit/domains/connections/domain/passwords.py
@@ -18,6 +18,15 @@ def uses_db_password(config: ConnectionConfig) -> bool:
     if auth_type in ("ad_default", "ad_integrated", "windows"):
         return False
 
+    if config.db_type == "postgresql":
+        from sqlit.domains.connections.providers.postgresql.auth import (
+            POSTGRES_AUTH_AZURE_ENTRA_CLI,
+            get_postgres_auth_method,
+        )
+
+        if get_postgres_auth_method(config) == POSTGRES_AUTH_AZURE_ENTRA_CLI:
+            return False
+
     if config.db_type == "trino":
         auth_method = str(config.options.get("trino_auth_method", config.extra_options.get("trino_auth_method", "basic"))).lower()
         if auth_method in {"none", "kerberos", "gssapi"}:

--- a/sqlit/domains/connections/providers/postgresql/adapter.py
+++ b/sqlit/domains/connections/providers/postgresql/adapter.py
@@ -72,8 +72,16 @@ class PostgreSQLAdapter(PostgresBaseAdapter):
     def driver_import_names(self) -> tuple[str, ...]:
         return ("psycopg2",)
 
+    def normalize_config(self, config: ConnectionConfig) -> ConnectionConfig:
+        from sqlit.domains.connections.providers.postgresql.auth import (
+            normalize_postgres_auth,
+        )
+
+        return normalize_postgres_auth(config)
+
     def connect(self, config: ConnectionConfig) -> Any:
         """Connect to PostgreSQL database."""
+        config = self.normalize_config(config)
         psycopg2 = self._import_driver_module(
             "psycopg2",
             driver_name=self.name,
@@ -100,8 +108,15 @@ class PostgreSQLAdapter(PostgresBaseAdapter):
             connect_args["port"] = int(endpoint.port or get_default_port("postgresql"))
         if endpoint.username:
             connect_args["user"] = endpoint.username
-        if endpoint.password is not None:
-            connect_args["password"] = endpoint.password
+        password = endpoint.password
+        if password is None and endpoint.password_command:
+            from sqlit.domains.connections.domain.password_command import (
+                run_password_command,
+            )
+
+            password = run_password_command(endpoint.password_command)
+        if password is not None:
+            connect_args["password"] = password
 
         tls_mode = get_tls_mode(config)
         tls_ca, tls_cert, tls_key, tls_key_password = get_tls_files(config)

--- a/sqlit/domains/connections/providers/postgresql/auth.py
+++ b/sqlit/domains/connections/providers/postgresql/auth.py
@@ -1,0 +1,32 @@
+"""Authentication helpers for PostgreSQL connections."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlit.domains.connections.domain.config import ConnectionConfig
+
+POSTGRES_AUTH_PASSWORD = "password"
+POSTGRES_AUTH_AZURE_ENTRA_CLI = "azure_entra_cli"
+AZURE_ENTRA_PASSWORD_COMMAND = "az account get-access-token --resource-type oss-rdbms --query accessToken --output tsv"
+
+
+def get_postgres_auth_method(config: ConnectionConfig) -> str:
+    return str(config.get_option("postgres_auth_method", POSTGRES_AUTH_PASSWORD)).lower()
+
+
+def normalize_postgres_auth(config: ConnectionConfig) -> ConnectionConfig:
+    endpoint = config.tcp_endpoint
+    if endpoint is None:
+        return config
+    if "postgres_auth_method" not in config.options and endpoint.password_command == AZURE_ENTRA_PASSWORD_COMMAND:
+        # Preserve and adopt connections that used the generic password-command
+        # support before Azure Entra became a first-class authentication mode.
+        config.set_option("postgres_auth_method", POSTGRES_AUTH_AZURE_ENTRA_CLI)
+    if get_postgres_auth_method(config) == POSTGRES_AUTH_AZURE_ENTRA_CLI:
+        endpoint.password = None
+        endpoint.password_command = AZURE_ENTRA_PASSWORD_COMMAND
+    elif endpoint.password_command == AZURE_ENTRA_PASSWORD_COMMAND:
+        endpoint.password_command = None
+    return config

--- a/sqlit/domains/connections/providers/postgresql/schema.py
+++ b/sqlit/domains/connections/providers/postgresql/schema.py
@@ -1,15 +1,26 @@
 """Connection schema for PostgreSQL."""
 
+from sqlit.domains.connections.providers.postgresql.auth import (
+    POSTGRES_AUTH_AZURE_ENTRA_CLI,
+    POSTGRES_AUTH_PASSWORD,
+)
 from sqlit.domains.connections.providers.schema_helpers import (
     SSH_FIELDS,
     TLS_FIELDS,
     ConnectionSchema,
+    FieldType,
+    SchemaField,
+    SelectOption,
     _database_field,
-    _password_field,
     _port_field,
     _server_field,
     _username_field,
 )
+
+
+def _auth_is_password(values: dict) -> bool:
+    return values.get("postgres_auth_method", POSTGRES_AUTH_PASSWORD) == POSTGRES_AUTH_PASSWORD
+
 
 SCHEMA = ConnectionSchema(
     db_type="postgresql",
@@ -18,8 +29,28 @@ SCHEMA = ConnectionSchema(
         _server_field(required=False),
         _port_field("5432"),
         _database_field(),
+        SchemaField(
+            name="postgres_auth_method",
+            label="Authentication",
+            field_type=FieldType.DROPDOWN,
+            options=(
+                SelectOption(POSTGRES_AUTH_PASSWORD, "Password"),
+                SelectOption(
+                    POSTGRES_AUTH_AZURE_ENTRA_CLI,
+                    "Azure Entra ID (Azure CLI)",
+                ),
+            ),
+            default=POSTGRES_AUTH_PASSWORD,
+        ),
         _username_field(required=False),
-        _password_field(),
+        SchemaField(
+            name="password",
+            label="Password",
+            field_type=FieldType.PASSWORD,
+            placeholder="(empty = ask every connect)",
+            group="credentials",
+            visible_when=_auth_is_password,
+        ),
     )
     + SSH_FIELDS
     + TLS_FIELDS,

--- a/sqlit/domains/connections/store/connections.py
+++ b/sqlit/domains/connections/store/connections.py
@@ -130,12 +130,16 @@ class ConnectionStore(JSONFileStore):
             config: ConnectionConfig to populate with credentials.
         """
         endpoint = config.tcp_endpoint
-        if endpoint and endpoint.password is None:
+        if endpoint and endpoint.password is None and not endpoint.password_command:
             password = self.credentials_service.get_password(config.name)
             if password is not None:
                 endpoint.password = password
 
-        if config.tunnel and config.tunnel.password is None:
+        if (
+            config.tunnel
+            and config.tunnel.password is None
+            and not config.tunnel.password_command
+        ):
             ssh_password = self.credentials_service.get_ssh_password(config.name)
             if ssh_password is not None:
                 config.tunnel.password = ssh_password
@@ -295,9 +299,17 @@ class ConnectionStore(JSONFileStore):
             target = copy.deepcopy(connection)
             try:
                 endpoint = target.tcp_endpoint
-                if endpoint and endpoint.password is None:
+                if (
+                    endpoint
+                    and endpoint.password is None
+                    and not endpoint.password_command
+                ):
                     endpoint.password = self.credentials_service.get_password_for_migration(previous_name)  # type: ignore[arg-type]
-                if target.tunnel and target.tunnel.password is None:
+                if (
+                    target.tunnel
+                    and target.tunnel.password is None
+                    and not target.tunnel.password_command
+                ):
                     target.tunnel.password = self.credentials_service.get_ssh_password_for_migration(previous_name)  # type: ignore[arg-type]
                 destination_db_password = self.credentials_service.get_password_for_migration(connection.name)
                 destination_ssh_password = self.credentials_service.get_ssh_password_for_migration(

--- a/tests/cli/test_cli_main.py
+++ b/tests/cli/test_cli_main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -36,12 +37,99 @@ def test_cli_connections_list_empty(tmp_path: Path, monkeypatch):
     assert "No saved connections." in result.stdout
 
 
+def test_cli_edit_selects_postgres_entra_auth(tmp_path: Path, monkeypatch):
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text('{"allow_plaintext_credentials": true}', encoding="utf-8")
+    monkeypatch.setenv("SQLIT_CONFIG_DIR", str(tmp_path))
+    created = run_cli(
+        "connections",
+        "add",
+        "postgresql",
+        "--name",
+        "Azure",
+        "--server",
+        "localhost",
+        "--username",
+        "developer",
+        "--password",
+        "old-password",
+        check=False,
+    )
+    assert created.returncode == 0, created.stderr
+
+    edited = run_cli(
+        "connections",
+        "edit",
+        "Azure",
+        "--postgres-auth-method",
+        "azure_entra_cli",
+        "--password",
+        "must-not-be-kept",
+        check=False,
+    )
+
+    assert edited.returncode == 0, edited.stderr
+    payload = json.loads((tmp_path / "connections.json").read_text())
+    saved = payload["connections"][0]
+    assert saved["options"]["postgres_auth_method"] == "azure_entra_cli"
+    assert saved["endpoint"]["password"] is None
+    assert saved["endpoint"]["password_command"].startswith("az account get-access-token")
+
+    edited_again = run_cli(
+        "connections",
+        "edit",
+        "Azure",
+        "--password",
+        "still-must-not-be-kept",
+        check=False,
+    )
+    assert edited_again.returncode == 0, edited_again.stderr
+    payload = json.loads((tmp_path / "connections.json").read_text())
+    assert payload["connections"][0]["endpoint"]["password"] is None
+    assert payload["connections"][0]["options"]["postgres_auth_method"] == "azure_entra_cli"
+
+
+def test_cli_preserves_legacy_azure_password_command(tmp_path: Path, monkeypatch):
+    from sqlit.domains.connections.providers.postgresql.auth import (
+        AZURE_ENTRA_PASSWORD_COMMAND,
+    )
+
+    settings_path = tmp_path / "settings.json"
+    settings_path.write_text('{"allow_plaintext_credentials": true}', encoding="utf-8")
+    monkeypatch.setenv("SQLIT_CONFIG_DIR", str(tmp_path))
+
+    result = run_cli(
+        "connections",
+        "add",
+        "postgresql",
+        "--name",
+        "LegacyAzure",
+        "--server",
+        "localhost",
+        "--username",
+        "developer",
+        "--password-command",
+        AZURE_ENTRA_PASSWORD_COMMAND,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads((tmp_path / "connections.json").read_text())
+    saved = payload["connections"][0]
+    assert saved["options"]["postgres_auth_method"] == "azure_entra_cli"
+    assert saved["endpoint"]["password_command"] == AZURE_ENTRA_PASSWORD_COMMAND
+
+
 def test_url_stdin_creates_connection(tmp_path: Path):
     settings_path = tmp_path / "settings.json"
     settings_path.write_text('{"allow_plaintext_credentials": true}', encoding="utf-8")
 
     result = _run_cli_with_stdin(
-        "connections", "add", "--url-stdin", "--name", "StdinURL",
+        "connections",
+        "add",
+        "--url-stdin",
+        "--name",
+        "StdinURL",
         stdin="sqlite:///tmp/sqlit-stdin-test.db\n",
         env_config_dir=tmp_path,
     )
@@ -55,10 +143,13 @@ def test_url_stdin_rejects_when_url_also_provided(tmp_path: Path):
     settings_path.write_text('{"allow_plaintext_credentials": true}', encoding="utf-8")
 
     result = _run_cli_with_stdin(
-        "connections", "add",
-        "--url", "sqlite:///tmp/a.db",
+        "connections",
+        "add",
+        "--url",
+        "sqlite:///tmp/a.db",
         "--url-stdin",
-        "--name", "X",
+        "--name",
+        "X",
         stdin="sqlite:///tmp/b.db\n",
         env_config_dir=tmp_path,
     )
@@ -72,13 +163,20 @@ def test_password_stdin_mutex_with_password(tmp_path: Path):
     settings_path.write_text('{"allow_plaintext_credentials": true}', encoding="utf-8")
 
     result = _run_cli_with_stdin(
-        "connect", "postgresql",
-        "--name", "X",
-        "--server", "localhost",
-        "--port", "5432",
-        "--database", "d",
-        "--username", "u",
-        "--password", "cleartext",
+        "connect",
+        "postgresql",
+        "--name",
+        "X",
+        "--server",
+        "localhost",
+        "--port",
+        "5432",
+        "--database",
+        "d",
+        "--username",
+        "u",
+        "--password",
+        "cleartext",
         "--password-stdin",
         stdin="frompipe\n",
         env_config_dir=tmp_path,
@@ -93,7 +191,9 @@ def test_multiple_stdin_flags_rejected(tmp_path: Path):
     settings_path.write_text('{"allow_plaintext_credentials": true}', encoding="utf-8")
 
     result = _run_cli_with_stdin(
-        "connections", "edit", "Nonexistent",
+        "connections",
+        "edit",
+        "Nonexistent",
         "--password-stdin",
         "--ssh-password-stdin",
         stdin="x\n",
@@ -110,12 +210,18 @@ def test_password_stdin_eof_errors_cleanly(tmp_path: Path):
     settings_path.write_text('{"allow_plaintext_credentials": true}', encoding="utf-8")
 
     result = _run_cli_with_stdin(
-        "connect", "postgresql",
-        "--name", "X",
-        "--server", "localhost",
-        "--port", "5432",
-        "--database", "d",
-        "--username", "u",
+        "connect",
+        "postgresql",
+        "--name",
+        "X",
+        "--server",
+        "localhost",
+        "--port",
+        "5432",
+        "--database",
+        "d",
+        "--username",
+        "u",
         "--password-stdin",
         stdin="",
         env_config_dir=tmp_path,

--- a/tests/integration/test_postgres_entra_gallery.py
+++ b/tests/integration/test_postgres_entra_gallery.py
@@ -1,0 +1,62 @@
+"""Opt-in screenshots for PostgreSQL Azure Entra authentication."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from textual.widgets import Select
+
+from sqlit.domains.connections.providers.postgresql.auth import (
+    POSTGRES_AUTH_AZURE_ENTRA_CLI,
+)
+from sqlit.shared.app.runtime import MockConfig, RuntimeConfig
+from tests.ui.conftest import ConnectionScreenTestApp
+from tests.ui.mocks import build_test_services
+
+_OUTPUT = os.environ.get("SQLIT_POSTGRES_ENTRA_SCREENSHOTS_DIR")
+pytestmark = pytest.mark.skipif(not _OUTPUT, reason="screenshot output is not configured")
+
+
+def _shot(app: ConnectionScreenTestApp, output: Path, name: str) -> None:
+    app.save_screenshot(path=output, filename=f"{name}.svg")
+
+
+@pytest.mark.asyncio
+async def test_postgres_entra_connection_gallery() -> None:
+    assert _OUTPUT is not None
+    output = Path(_OUTPUT)
+    output.mkdir(parents=True, exist_ok=True)
+    for old in output.glob("*.svg"):
+        old.unlink()
+
+    services = build_test_services(
+        runtime=RuntimeConfig(mock=MockConfig(enabled=True))
+    )
+    app = ConnectionScreenTestApp(
+        prefill_values={"db_type": "postgresql"},
+        services=services,
+    )
+    async with app.run_test(size=(112, 40)) as pilot:
+        screen = app.screen
+        screen.query_one("#conn-name").value = "azure-production"
+        screen.query_one("#field-server").value = (
+            "example.postgres.database.azure.com"
+        )
+        screen.query_one("#field-database").value = "appdb"
+        screen.query_one("#field-username").value = "developer@example.com"
+        await pilot.pause()
+        _shot(app, output, "01-postgres-password-auth")
+
+        auth = screen.query_one("#field-postgres_auth_method", Select)
+        auth.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        _shot(app, output, "02-postgres-auth-options")
+
+        await pilot.press("down", "enter")
+        await pilot.pause()
+        assert auth.value == POSTGRES_AUTH_AZURE_ENTRA_CLI
+        assert "hidden" in screen.query_one("#container-password").classes
+        _shot(app, output, "03-postgres-entra-selected")

--- a/tests/test_connection_store_save_one.py
+++ b/tests/test_connection_store_save_one.py
@@ -213,6 +213,20 @@ class TestSaveOne:
 
         assert self.creds.get_password("a") == "kept"
 
+    def test_save_one_password_command_removes_stored_password(self) -> None:
+        store = self._create_store()
+        store.save_one(self._make("a", password="stale"))
+        dynamic = self._make("a", password=None)
+        assert dynamic.tcp_endpoint is not None
+        dynamic.tcp_endpoint.password_command = "dynamic-token"
+
+        store.save_one(dynamic)
+
+        assert self.creds.get_password("a") is None
+        assert "a" in self.creds.delete_db
+        endpoint = self._json()[0]["endpoint"]
+        assert endpoint["password_command"] == "dynamic-token"
+
     # --- rename ------------------------------------------------------------
 
     def test_save_one_rename_moves_credentials(self) -> None:
@@ -246,6 +260,19 @@ class TestSaveOne:
         assert self.creds.get_ssh_password("old") is None
         assert self.creds.get_password("new") == "secret"
         assert self.creds.get_ssh_password("new") == "ssh_secret"
+
+    def test_save_one_rename_to_password_command_drops_old_password(self) -> None:
+        store = self._create_store()
+        store.save_one(self._make("old", password="stale"))
+        renamed = self._make("new", password=None)
+        assert renamed.tcp_endpoint is not None
+        renamed.tcp_endpoint.password_command = "dynamic-token"
+
+        store.save_one(renamed, previous_name="old")
+
+        assert self.creds.get_password("old") is None
+        assert self.creds.get_password("new") is None
+        assert {item["name"] for item in self._json()} == {"new"}
 
     def test_save_one_failed_rename_keeps_original_usable(self) -> None:
         store = self._create_store()

--- a/tests/test_credentials_connection_store.py
+++ b/tests/test_credentials_connection_store.py
@@ -125,6 +125,31 @@ class TestConnectionStoreWithCredentials:
         assert loaded[0].tunnel is not None
         assert loaded[0].tunnel.password == "ssh_secret"
 
+    def test_load_ignores_stale_passwords_when_commands_are_configured(self) -> None:
+        """Dynamic credentials must take precedence over leftover keyring values."""
+        self.creds_service.set_password("test_db", "stale_password")
+        self.creds_service.set_ssh_password("test_db", "stale_ssh_password")
+        config = ConnectionConfig(
+            name="test_db",
+            db_type="postgresql",
+            server="localhost",
+            username="user",
+            password_command="dynamic-db-token",
+            ssh_enabled=True,
+            ssh_host="bastion",
+            ssh_username="ssh_user",
+            ssh_password_command="dynamic-ssh-token",
+        )
+        json_path = Path(self.tmpdir) / "connections.json"
+        with open(json_path, "w") as f:
+            json.dump([config.to_dict(include_passwords=False)], f)
+
+        loaded = self._create_store().load_all()
+
+        assert loaded[0].tcp_endpoint.password is None
+        assert loaded[0].tunnel is not None
+        assert loaded[0].tunnel.password is None
+
     def test_delete_removes_credentials(self) -> None:
         """Test that deleting a connection removes credentials."""
         store = self._create_store()

--- a/tests/ui/test_connection_screen.py
+++ b/tests/ui/test_connection_screen.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import pytest
+from textual.widgets import Select
 
 from sqlit.domains.connections.domain.config import FileEndpoint
+from sqlit.domains.connections.providers.postgresql.auth import (
+    AZURE_ENTRA_PASSWORD_COMMAND,
+    POSTGRES_AUTH_AZURE_ENTRA_CLI,
+)
 from tests.helpers import ConnectionConfig
 
 from .conftest import ConnectionScreenTestApp
@@ -173,6 +178,38 @@ class TestConnectionScreen:
             tls_ca_container = screen.query_one("#container-tls_ca")
             assert "hidden" not in tls_mode_container.classes
             assert "hidden" in tls_ca_container.classes
+
+    @pytest.mark.asyncio
+    async def test_postgres_entra_hides_password_and_saves_dynamic_auth(self):
+        app = ConnectionScreenTestApp(prefill_values={"db_type": "postgresql"})
+
+        async with app.run_test(size=(100, 35)) as pilot:
+            screen = app.screen
+            password_container = screen.query_one("#container-password")
+            assert "hidden" not in password_container.classes
+
+            auth = screen.query_one("#field-postgres_auth_method", Select)
+            auth.value = POSTGRES_AUTH_AZURE_ENTRA_CLI
+            await pilot.pause()
+
+            assert "hidden" in password_container.classes
+            screen.query_one("#conn-name").value = "azure-postgres"
+            screen.query_one("#field-server").value = (
+                "example.postgres.database.azure.com"
+            )
+            screen.query_one("#field-database").value = "appdb"
+            screen.query_one("#field-username").value = "developer@example.com"
+            config = screen._get_config()
+
+            assert config is not None
+            assert config.get_option("postgres_auth_method") == (
+                POSTGRES_AUTH_AZURE_ENTRA_CLI
+            )
+            assert config.tcp_endpoint is not None
+            assert config.tcp_endpoint.password is None
+            assert config.tcp_endpoint.password_command == (
+                AZURE_ENTRA_PASSWORD_COMMAND
+            )
 
 
 class TestTabNavigation:

--- a/tests/unit/test_connection_manager_dynamic_password.py
+++ b/tests/unit/test_connection_manager_dynamic_password.py
@@ -1,0 +1,173 @@
+"""Dynamic password-command coverage for TUI connection management."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from sqlit.core.connection_manager import ConnectionManager
+from sqlit.domains.connections.domain.password_command import PasswordCommandError
+from sqlit.domains.connections.providers.postgresql.auth import (
+    AZURE_ENTRA_PASSWORD_COMMAND,
+    POSTGRES_AUTH_AZURE_ENTRA_CLI,
+)
+from tests.helpers import ConnectionConfig
+
+
+def test_connect_keeps_postgres_dynamic_command_unresolved_in_session() -> None:
+    captured_configs: list[ConnectionConfig] = []
+    services = MagicMock()
+    services.session_factory.side_effect = captured_configs.append
+    manager = ConnectionManager(services)
+    config = ConnectionConfig(
+        name="azure-postgres",
+        db_type="postgresql",
+        server="example.postgres.database.azure.com",
+        username="developer@example.com",
+        password=None,
+        options={"postgres_auth_method": POSTGRES_AUTH_AZURE_ENTRA_CLI},
+    )
+
+    with patch(
+        "sqlit.domains.connections.domain.password_command.run_password_command",
+    ) as run_command:
+        manager.connect(config)
+        manager.connect(config)
+
+    run_command.assert_not_called()
+    assert len(captured_configs) == 2
+    for captured in captured_configs:
+        assert captured.tcp_endpoint is not None
+        assert captured.tcp_endpoint.password is None
+        assert captured.tcp_endpoint.password_command == AZURE_ENTRA_PASSWORD_COMMAND
+    assert config.tcp_endpoint is not None
+    assert config.tcp_endpoint.password is None
+
+
+def test_connection_test_resolves_dynamic_password_in_postgres_adapter() -> None:
+    from sqlit.domains.connections.providers.postgresql.adapter import PostgreSQLAdapter
+
+    connection = MagicMock()
+    driver = MagicMock()
+    driver.connect.return_value = connection
+    adapter = PostgreSQLAdapter()
+    adapter._import_driver_module = MagicMock(return_value=driver)  # type: ignore[method-assign]
+    provider = MagicMock()
+    provider.connection_factory = adapter
+    services = MagicMock()
+    services.tunnel_factory.return_value = (None, "localhost", 5432)
+    services.provider_factory.return_value = provider
+    manager = ConnectionManager(services)
+    config = ConnectionConfig(
+        name="azure-postgres",
+        db_type="postgresql",
+        options={"postgres_auth_method": POSTGRES_AUTH_AZURE_ENTRA_CLI},
+    )
+
+    with (
+        patch(
+            "sqlit.domains.connections.domain.password_command.run_password_command",
+            return_value="fresh-token",
+        ),
+        patch("sqlit.domains.connections.providers.postgresql.adapter._register_temporal_typecasters"),
+    ):
+        result = manager.test_connection(config)
+
+    assert result.ok is True
+    assert driver.connect.call_args.kwargs["password"] == "fresh-token"
+    connection.close.assert_called_once()
+
+
+def test_connection_test_surfaces_password_command_failure() -> None:
+    from sqlit.domains.connections.providers.postgresql.adapter import PostgreSQLAdapter
+
+    services = MagicMock()
+    adapter = PostgreSQLAdapter()
+    adapter._import_driver_module = MagicMock(return_value=MagicMock())  # type: ignore[method-assign]
+    provider = MagicMock()
+    provider.connection_factory = adapter
+    services.tunnel_factory.return_value = (None, "localhost", 5432)
+    services.provider_factory.return_value = provider
+    manager = ConnectionManager(services)
+    config = ConnectionConfig(
+        name="azure-postgres",
+        db_type="postgresql",
+        options={"postgres_auth_method": POSTGRES_AUTH_AZURE_ENTRA_CLI},
+    )
+
+    with patch(
+        "sqlit.domains.connections.domain.password_command.run_password_command",
+        side_effect=PasswordCommandError("Azure CLI login required"),
+    ):
+        result = manager.test_connection(config)
+
+    assert result.ok is False
+    assert isinstance(result.error, PasswordCommandError)
+    assert "Azure CLI login required" in str(result.error)
+
+
+def test_connect_does_not_run_ssh_password_command_for_key_auth() -> None:
+    services = MagicMock()
+    manager = ConnectionManager(services)
+    config = ConnectionConfig(
+        name="postgres-through-bastion",
+        db_type="postgresql",
+        password="database-password",
+        ssh_enabled=True,
+        ssh_host="bastion",
+        ssh_username="developer",
+        ssh_auth_type="key",
+        ssh_key_path="~/.ssh/id_ed25519",
+        ssh_password_command="must-not-run",
+    )
+
+    with patch("sqlit.domains.connections.domain.password_command.run_password_command") as run_command:
+        manager.connect(config)
+
+    run_command.assert_not_called()
+    services.session_factory.assert_called_once()
+
+
+def test_connect_prefers_explicit_passwords_over_commands() -> None:
+    services = MagicMock()
+    manager = ConnectionManager(services)
+    config = ConnectionConfig(
+        name="explicit-passwords",
+        db_type="mysql",
+        server="localhost",
+        username="developer",
+        password="database-password",
+        password_command="must-not-run-db",
+        ssh_enabled=True,
+        ssh_host="bastion",
+        ssh_username="developer",
+        ssh_auth_type="password",
+        ssh_password="ssh-password",
+        ssh_password_command="must-not-run-ssh",
+    )
+
+    with patch("sqlit.domains.connections.domain.password_command.run_password_command") as run_command:
+        manager.connect(config)
+
+    run_command.assert_not_called()
+
+
+def test_populate_credentials_does_not_override_ssh_password_command() -> None:
+    services = MagicMock()
+    services.credentials_service.get_ssh_password.return_value = "stale-password"
+    manager = ConnectionManager(services)
+    config = ConnectionConfig(
+        name="ssh-command",
+        db_type="postgresql",
+        password="database-password",
+        ssh_enabled=True,
+        ssh_host="bastion",
+        ssh_username="developer",
+        ssh_auth_type="password",
+        ssh_password_command="dynamic-ssh-password",
+    )
+
+    manager.populate_credentials(config)
+
+    assert config.tunnel is not None
+    assert config.tunnel.password is None
+    services.credentials_service.get_ssh_password.assert_not_called()

--- a/tests/unit/test_postgres_entra_auth.py
+++ b/tests/unit/test_postgres_entra_auth.py
@@ -1,0 +1,118 @@
+"""PostgreSQL Azure Entra authentication configuration."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from sqlit.domains.connections.domain.passwords import needs_db_password
+from sqlit.domains.connections.providers.postgresql import adapter as adapter_module
+from sqlit.domains.connections.providers.postgresql.adapter import PostgreSQLAdapter
+from sqlit.domains.connections.providers.postgresql.auth import (
+    AZURE_ENTRA_PASSWORD_COMMAND,
+    POSTGRES_AUTH_AZURE_ENTRA_CLI,
+    POSTGRES_AUTH_PASSWORD,
+    normalize_postgres_auth,
+)
+from sqlit.domains.connections.providers.postgresql.schema import SCHEMA
+from tests.helpers import ConnectionConfig
+
+
+def test_entra_auth_adds_dynamic_azure_cli_token_command() -> None:
+    config = ConnectionConfig(
+        name="azure-postgres",
+        db_type="postgresql",
+        server="example.postgres.database.azure.com",
+        username="developer@example.com",
+        password="must-not-be-stored",
+        options={"postgres_auth_method": POSTGRES_AUTH_AZURE_ENTRA_CLI},
+    )
+
+    normalized = PostgreSQLAdapter().normalize_config(config)
+
+    assert normalized.tcp_endpoint is not None
+    assert normalized.tcp_endpoint.password is None
+    assert normalized.tcp_endpoint.password_command == AZURE_ENTRA_PASSWORD_COMMAND
+    assert needs_db_password(normalized) is False
+
+
+def test_switching_back_to_password_removes_managed_command() -> None:
+    config = ConnectionConfig(
+        name="azure-postgres",
+        db_type="postgresql",
+        options={"postgres_auth_method": POSTGRES_AUTH_PASSWORD},
+        password_command=AZURE_ENTRA_PASSWORD_COMMAND,
+    )
+
+    normalized = PostgreSQLAdapter().normalize_config(config)
+
+    assert normalized.tcp_endpoint is not None
+    assert normalized.tcp_endpoint.password_command is None
+
+
+def test_existing_azure_password_command_migrates_to_entra_auth() -> None:
+    config = ConnectionConfig(
+        name="legacy-azure-postgres",
+        db_type="postgresql",
+        password_command=AZURE_ENTRA_PASSWORD_COMMAND,
+    )
+
+    normalized = normalize_postgres_auth(config)
+
+    assert normalized.get_option("postgres_auth_method") == POSTGRES_AUTH_AZURE_ENTRA_CLI
+    assert normalized.tcp_endpoint is not None
+    assert normalized.tcp_endpoint.password_command == AZURE_ENTRA_PASSWORD_COMMAND
+
+
+def test_normalization_clears_stale_password_in_entra_mode() -> None:
+    config = ConnectionConfig(
+        name="azure-postgres",
+        db_type="postgresql",
+        options={"postgres_auth_method": POSTGRES_AUTH_AZURE_ENTRA_CLI},
+    )
+    adapter = PostgreSQLAdapter()
+    first = adapter.normalize_config(config)
+    assert first.tcp_endpoint is not None
+    first.tcp_endpoint.password = "fresh-access-token"
+
+    second = adapter.normalize_config(first)
+
+    assert second.tcp_endpoint is not None
+    assert second.tcp_endpoint.password is None
+    assert second.tcp_endpoint.password_command == AZURE_ENTRA_PASSWORD_COMMAND
+
+
+def test_password_field_only_visible_for_password_auth() -> None:
+    password_field = next(field for field in SCHEMA.fields if field.name == "password")
+    assert password_field.visible_when is not None
+    assert password_field.visible_when({"postgres_auth_method": POSTGRES_AUTH_PASSWORD})
+    assert not password_field.visible_when({"postgres_auth_method": POSTGRES_AUTH_AZURE_ENTRA_CLI})
+
+
+def test_adapter_resolves_entra_token_for_direct_connection_paths() -> None:
+    config = ConnectionConfig(
+        name="azure-postgres",
+        db_type="postgresql",
+        server="example.postgres.database.azure.com",
+        database="appdb",
+        username="developer@example.com",
+        options={"postgres_auth_method": POSTGRES_AUTH_AZURE_ENTRA_CLI},
+    )
+    adapter = PostgreSQLAdapter()
+    driver = MagicMock()
+    connection = MagicMock()
+    driver.connect.return_value = connection
+    adapter._import_driver_module = MagicMock(return_value=driver)  # type: ignore[method-assign]
+
+    with (
+        patch(
+            "sqlit.domains.connections.domain.password_command.run_password_command",
+            return_value="fresh-token",
+        ) as run_command,
+        patch.object(adapter_module, "_register_temporal_typecasters"),
+    ):
+        result = adapter.connect(config)
+
+    assert result is connection
+    run_command.assert_called_once_with(AZURE_ENTRA_PASSWORD_COMMAND)
+    driver.connect.assert_called_once()
+    assert driver.connect.call_args.kwargs["password"] == "fresh-token"


### PR DESCRIPTION
Closes #160.

Adds an Azure Entra ID (Azure CLI) authentication option for PostgreSQL. SQLit retrieves a fresh access token for each physical connection, keeps passwords out of the form in this mode, and does not persist generated tokens.

Tests cover the UI, CLI, token refresh, persistence, migration, and credential precedence.