### PR TITLE
Change the query history popup layout to nvim style split layout from the stacked layout

### DIFF
--- a/sqlit/domains/query/ui/screens/query_history.py
+++ b/sqlit/domains/query/ui/screens/query_history.py
@@ -9,7 +9,7 @@ from typing import Any
 from textual.app import ComposeResult
 from rich.text import Text
 from textual.binding import Binding
-from textual.containers import VerticalScroll
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import OptionList, Static
 from textual.widgets.option_list import Option
@@ -37,20 +37,38 @@ class QueryHistoryScreen(ModalScreen):
     }
 
     #history-dialog {
-        width: 90;
-        max-width: 90%;
-        height: 80%;
-        max-height: 90%;
+        width: 120;
+        max-width: 95%;
+        height: 24;
+        min-height: 16;
+        max-height: 80%;
+    }
+
+    #history-filter {
+        background: $surface;
+    }
+
+    /* nvim-style split: list sidebar | preview window */
+    #history-split {
+        height: 1fr;
+        width: 1fr;
+    }
+
+    #history-list-pane {
+        width: 32;
+        min-width: 24;
+        max-width: 40%;
+        height: 1fr;
+        background: $surface;
+        border: none;
+        padding: 0;
     }
 
     #history-scroll {
         height: 1fr;
         background: $surface;
         border: none;
-    }
-
-    #history-filter {
-        background: $surface;
+        padding: 0;
     }
 
     #history-list {
@@ -70,14 +88,19 @@ class QueryHistoryScreen(ModalScreen):
         padding: 2;
     }
 
-    #history-preview-container {
-        height: 8;
-        min-height: 8;
-        max-height: 8;
+    #history-preview-pane {
+        width: 1fr;
+        height: 1fr;
         background: $surface-darken-1;
         border: none;
         padding: 1;
-        margin-top: 1;
+    }
+
+    #history-preview-container {
+        height: 1fr;
+        background: $surface-darken-1;
+        border: none;
+        padding: 0;
     }
 
     #history-preview {
@@ -199,18 +222,20 @@ class QueryHistoryScreen(ModalScreen):
 
         with Dialog(id="history-dialog", title=title, shortcuts=shortcuts):
             yield FilterInput(id="history-filter")
-            with VerticalScroll(id="history-scroll"):
-                if self._merged_entries:
-                    options = []
-                    for entry in self._merged_entries:
-                        options.append(self._build_option(entry))
+            with Horizontal(id="history-split"):
+                with Vertical(id="history-list-pane"):
+                    with VerticalScroll(id="history-scroll"):
+                        if self._merged_entries:
+                            options = []
+                            for entry in self._merged_entries:
+                                options.append(self._build_option(entry))
 
-                    yield OptionList(*options, id="history-list")
-                else:
-                    yield Static(empty_message, id="history-empty")
-
-            with VerticalScroll(id="history-preview-container"):
-                yield Static("", id="history-preview")
+                            yield OptionList(*options, id="history-list")
+                        else:
+                            yield Static(empty_message, id="history-empty")
+                with Vertical(id="history-preview-pane"):
+                    with VerticalScroll(id="history-preview-container"):
+                        yield Static("", id="history-preview")
 
     def on_mount(self) -> None:
         if self._merged_entries:

--- a/sqlit/domains/query/ui/screens/query_history.py
+++ b/sqlit/domains/query/ui/screens/query_history.py
@@ -28,6 +28,7 @@ class QueryHistoryScreen(ModalScreen):
         Binding("d", "delete", "Delete"),
         Binding("asterisk", "toggle_star", "Star"),
         Binding("slash", "open_filter", "Filter"),
+        Binding("tab", "toggle_pane", "Pane", priority=True),
     ]
 
     CSS = """
@@ -64,6 +65,22 @@ class QueryHistoryScreen(ModalScreen):
         padding: 0;
     }
 
+    #history-list-pane.active-pane {
+        border-left: tall $primary;
+    }
+
+    #history-preview-pane {
+        width: 1fr;
+        height: 1fr;
+        background: $surface-darken-1;
+        border: none;
+        padding: 1;
+    }
+
+    #history-preview-pane.active-pane {
+        border-left: tall $primary;
+    }
+
     #history-scroll {
         height: 1fr;
         background: $surface;
@@ -86,14 +103,6 @@ class QueryHistoryScreen(ModalScreen):
         text-align: center;
         color: $text-muted;
         padding: 2;
-    }
-
-    #history-preview-pane {
-        width: 1fr;
-        height: 1fr;
-        background: $surface-darken-1;
-        border: none;
-        padding: 1;
     }
 
     #history-preview-container {
@@ -133,6 +142,7 @@ class QueryHistoryScreen(ModalScreen):
         self._filter_query = ""
         self._filter_fuzzy = False
         self._filtered_entries: list[QueryHistoryEntry] = []
+        self._active_pane = "list"  # "list" or "preview"
 
     def _merge_entries(self) -> list[QueryHistoryEntry]:
         """Merge history entries with starred-only queries.
@@ -216,7 +226,7 @@ class QueryHistoryScreen(ModalScreen):
         else:
             title = f"Query History - {self.connection_name}"
             empty_message = "No query history for this connection"
-        shortcuts = [("Select", "<enter>"), ("Star", "*"), ("Delete", "D")]
+        shortcuts = [("Select", "<enter>"), ("Star", "*"), ("Delete", "D"), ("Pane", "<tab>")]
 
         self._merged_entries = self._merge_entries()
 
@@ -250,8 +260,38 @@ class QueryHistoryScreen(ModalScreen):
             filter_input.hide()
         except Exception:
             pass
+        self._set_active_pane("list")
         if self._auto_open_filter:
             self.action_open_filter()
+
+    def action_toggle_pane(self) -> None:
+        """Switch focus between the list pane and the preview pane (Tab).
+
+        Works while a search filter is open so the user can jump to the
+        preview to read a query without closing the filter.
+        """
+        self._set_active_pane("preview" if self._active_pane == "list" else "list")
+
+    def _set_active_pane(self, pane: str) -> None:
+        """Mark ``pane`` as active, update focus, and refresh pane borders."""
+        self._active_pane = pane
+        try:
+            list_pane = self.query_one("#history-list-pane", Vertical)
+            preview_pane = self.query_one("#history-preview-pane", Vertical)
+        except Exception:
+            return
+        list_pane.set_class(pane == "list", "active-pane")
+        preview_pane.set_class(pane == "preview", "active-pane")
+        if pane == "list":
+            try:
+                self.query_one("#history-list", OptionList).focus()
+            except Exception:
+                pass
+        else:
+            try:
+                self.query_one("#history-preview-container", VerticalScroll).focus()
+            except Exception:
+                pass
 
     def on_option_list_option_highlighted(self, event: OptionList.OptionHighlighted) -> None:
         if event.option_list.id == "history-list":
@@ -264,6 +304,14 @@ class QueryHistoryScreen(ModalScreen):
         if idx < len(entries):
             preview = self.query_one("#history-preview", Static)
             preview.update(Text(entries[idx].query))
+            # Reset the preview scroll to the top so each query starts at
+            # its first line instead of inheriting the previous query's
+            # scroll offset.
+            try:
+                container = self.query_one("#history-preview-container", VerticalScroll)
+                container.scroll_home(animate=False)
+            except Exception:
+                pass
 
     def action_select(self) -> None:
         entries = self._get_display_entries()
@@ -328,6 +376,22 @@ class QueryHistoryScreen(ModalScreen):
         self.dismiss(None)
 
     def on_key(self, event: Any) -> None:
+        # j/k always navigate the active pane, even while a filter is open:
+        # in the preview pane they scroll the query; in the list pane they
+        # move the highlight (no filter) or type into the filter (filter open).
+        if event.key in ("j", "k") and self._active_pane == "preview":
+            try:
+                preview = self.query_one("#history-preview-container", VerticalScroll)
+            except Exception:
+                return
+            if event.key == "j":
+                preview.scroll_down()
+            else:
+                preview.scroll_up()
+            event.prevent_default()
+            event.stop()
+            return
+
         if not self._filter_active:
             if event.key in ("j", "k"):
                 try:
@@ -340,6 +404,14 @@ class QueryHistoryScreen(ModalScreen):
                     option_list.action_cursor_up()
                 event.prevent_default()
                 event.stop()
+            return
+
+        # Filter-text editing (backspace + printable chars) is bound to the
+        # list pane: the list pane is "type to filter" mode. In the preview
+        # pane these keys are ignored so reading a query can't accidentally
+        # mutate the filter; only j/k (scroll), Tab, and action bindings
+        # (enter/d/*/escape) remain active there.
+        if self._active_pane != "list":
             return
 
         key = event.key
@@ -365,6 +437,17 @@ class QueryHistoryScreen(ModalScreen):
 
     def action_open_filter(self) -> None:
         if not self._merged_entries:
+            return
+        # `/` is the filter-entry key, and filter text is only editable in
+        # the list pane. If the user is in the preview pane, jump to the
+        # list pane first so the opened filter is immediately typeable
+        # instead of silently swallowing keystrokes.
+        if self._active_pane != "list":
+            self._set_active_pane("list")
+        # Only (re)initialise the filter when it wasn't already open, so
+        # pressing `/` to hop back to the list pane preserves any text the
+        # user has already typed.
+        if self._filter_active:
             return
         self._filter_active = True
         self._filter_text = ""


### PR DESCRIPTION
Hi @Maxteabag 

I am proposing this change to improve the ui/ux of historical search, which in my experience improves navigating large queries (I am been using this for the past week since I have added this code to repo in my dev flow), specially with keyboard-only workflow, I have attached the video and screenshots my new ui, let me know your feedback on this how do you feel about it.

Proposed Change:
- Instead of using a stacked layout for query history dialog box let's use a side by side one, as often happens that the query might only differ slightly and you want to check which one is that you want to select and hence the scroll the preview pane, 
- previously, preview pane was very small before which does not allows for proper walkthrough of the old queries

Evidence:
before
<img width="3258" height="1564" alt="00-before-history" src="https://github.com/user-attachments/assets/82618146-5868-47e4-8e60-1dc1b8c13aab" />
after

<img width="3258" height="1564" alt="01-history-split-list" src="https://github.com/user-attachments/assets/d2f75170-3dd1-4130-94d2-b9f680c6627e" />

for long queries
<img width="3258" height="1564" alt="02-history-preview-long-query" src="https://github.com/user-attachments/assets/16420b30-3ad0-458f-9129-9cf0302b9a1f" />

here is a video demo (key press can be seen at the bottom)
https://github.com/user-attachments/assets/ee87b07e-d2ba-459a-a627-e20dedd677e6


Caveats:
- This is my first time making ui/ux changes to TUI app, so any feedback, critical or otherwise is appreciated  
- This work was done completely with the assistance of Coding Agent (Codex: GPT-6-Astra), I have read the code, and made minor cleanups

